### PR TITLE
fix: correct Android app name label and enforce issue subtask hierarchy (#140)

### DIFF
--- a/.github/skills/github-issue-subtasks-standardizer/SKILL.md
+++ b/.github/skills/github-issue-subtasks-standardizer/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: github-issue-subtasks-standardizer
+description: >
+  Standardize issue subtask creation for this repository. Creates task issues,
+  enforces parent-child relationships using GitHub sub-issues, and writes
+  traceable links/checklists back to the parent issue before implementation starts.
+allowed-tools: shell
+---
+
+## Purpose
+
+Create implementation-ready task breakdowns for a parent issue with explicit
+GitHub parent-child links, so progress can be tracked reliably and consistently.
+
+## Inputs
+
+- Parent issue number (required)
+- Owner/repo (infer from git remote when possible)
+- Optional: requested number of subtasks or suggested task titles
+
+## Step 1 - Validate prerequisites
+
+1. Confirm GitHub auth:
+```
+gh auth status
+```
+2. Resolve repository slug from:
+- `git remote get-url origin` (preferred)
+- explicit input
+
+## Step 2 - Read parent issue context
+
+Fetch parent issue details:
+```
+gh issue view <parent> --repo <owner/repo> --json number,id,title,body,url,labels
+```
+
+Extract the scope and acceptance criteria to derive subtasks.
+
+## Step 3 - Create standardized subtasks
+
+Create 3-7 task issues with labels:
+- `task`
+- same type label as parent when useful (e.g., `bug`)
+
+Each subtask body must include:
+- `Parent: #<parent>`
+- Goal
+- Done When checklist
+
+Example:
+```
+gh issue create --repo <owner/repo> \
+  --title "[Task][#<parent>] <short task title>" \
+  --body "Parent: #<parent>\n\n## Goal\n...\n\n## Done When\n- ..." \
+  --label task
+```
+
+## Step 4 - Set true parent-child links (mandatory)
+
+After creating task issues, link each child to the parent with GraphQL:
+
+1. Get node IDs:
+```
+gh issue view <parent> --repo <owner/repo> --json id
+gh issue view <child> --repo <owner/repo> --json id
+```
+
+2. Add sub-issue relation:
+```
+gh api graphql \
+  -f query='mutation($parent:ID!,$child:ID!){addSubIssue(input:{issueId:$parent,subIssueId:$child}){issue{id}}}' \
+  -f parent=<PARENT_NODE_ID> \
+  -f child=<CHILD_NODE_ID>
+```
+
+Repeat for every child.
+
+## Step 5 - Verify hierarchy
+
+Verify parent contains expected sub-issues:
+```
+gh api graphql \
+  -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){issue(number:$number){number subIssues(first:50){nodes{number title state url}}}}}' \
+  -f owner=<owner> -f repo=<repo> -F number=<parent>
+```
+
+If any child is missing, re-run Step 4.
+
+## Step 6 - Update parent issue body
+
+Ensure parent issue has a `## Task Breakdown` section listing child issues:
+- [ ] #<child1> <title>
+- [ ] #<child2> <title>
+...
+
+Keep `<!-- enriched-by-copilot -->` as the final line when present.
+
+## Step 7 - Progress rules
+
+- Do not start code implementation until Step 5 passes.
+- Close child tasks as completed when done and leave completion comments with evidence.
+- Keep the parent issue open until implementation PR exists.
+
+## Quality rules
+
+- Parent-child relation must be a real GitHub sub-issue link, not only plain text references.
+- Child issue titles must be action-oriented and scoped to one deliverable.
+- Every child must have verifiable `Done When` criteria.
+- Parent issue must remain the single source of progress truth.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ Skills live in `.github/skills/<skill-name>/SKILL.md` and are invoked with `/ski
 | Skill | Purpose |
 |---|---|
 | `github-issue-enrichment` | Enrich a GitHub issue with full technical brief; marks issue to prevent re-processing |
+| `github-issue-subtasks-standardizer` | Standardize creation of task sub-issues and enforce true parent-child GitHub sub-issue links before implementation |
 | `github-actions-manager` | List workflows, inspect YAML health, check for timeouts and deprecated actions |
 | `github-action-runs-manager` | Fetch run status by PR/branch/commit, retrieve failure logs, classify root causes |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ Skills live in `.github/skills/<skill-name>/SKILL.md` and are invoked with `/ski
 - All features start from a GitHub issue enriched by `github.issues-manager`.
 - Issues can originate from the user (existing issue number) or be created fresh by `orchestrator` → `github.issues-manager` (Operation 7) from a natural-language description.
 - Enriched issues contain the marker `<!-- enriched-by-copilot -->` as their last line.
+- Before implementation starts on any issue, break work into explicit task-level child issues (or a clearly enumerated task checklist if child issues are not practical) and link them to the parent issue.
 - **Approval is required** before implementation starts on a newly created issue — `orchestrator` presents the enriched issue and waits for explicit user confirmation.
 - Task-level GitHub issues are created by `feature.breakdown` with label `task`.
 - Feature-level GitHub issues carry label `feature`; bug issues carry label `bug`.
@@ -92,6 +93,7 @@ Skills live in `.github/skills/<skill-name>/SKILL.md` and are invoked with `/ski
 - Do not create a duplicate parent issue during breakdown when a feature parent issue already exists.
 - Any detected hierarchy mismatch must be repaired by `github.issues-manager` before implementation continues.
 - Only `github.issues-manager` writes back to GitHub issues on behalf of other agents.
+- Do not close an issue until a pull request exists for the implemented changes and the issue references that PR.
 
 ## Branch Naming Convention
 
@@ -110,7 +112,9 @@ Branches are created via `gh issue develop` so they appear linked in the GitHub 
 - Always read `docs/constitution.md` before starting any feature work.
 - GitHub is the single source of truth — all features must have a GitHub issue.
 - Every issue must have a linked branch before implementation starts (Stage -1).
+- Always run task breakdown before coding: create child task issues (preferred) or an explicit task checklist in the issue, and track progress against it.
 - Validate `gh auth status` before any GitHub write operation.
 - Run `dotnet build` after every implementation task — do not accumulate build failures.
 - Never skip a test stage — fix or explicitly document blockers.
+- Open a PR for completed issue work before closing the issue, and include the PR link in the closure note.
 - Constitution violations must be escalated to `orchestrator`; never proceed silently.

--- a/src/MauiApp/NdiForAndroid.csproj
+++ b/src/MauiApp/NdiForAndroid.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>NdiForAndroid</RootNamespace>
     <AssemblyName>NdiForAndroid</AssemblyName>
+    <ApplicationTitle>NDI for Android</ApplicationTitle>
     <ApplicationId>com.ndi.android</ApplicationId>
     <ApplicationVersion>1</ApplicationVersion>
     <ApplicationDisplayVersion>1.0.0</ApplicationDisplayVersion>

--- a/src/MauiApp/Platforms/Android/AndroidManifest.xml
+++ b/src/MauiApp/Platforms/Android/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
 
     <application android:allowBackup="true"
+                 android:label="NDI for Android"
                  android:icon="@mipmap/appicon"
                  android:roundIcon="@mipmap/appicon_round"
                  android:supportsRtl="true">


### PR DESCRIPTION
## Summary\n- Fixes app display name regression by setting MAUI ApplicationTitle to NDI for Android\n- Sets explicit Android manifest ndroid:label to NDI for Android\n- Adds reusable skill .github/skills/github-issue-subtasks-standardizer/SKILL.md to standardize subtask creation and parent linking\n- Registers the new skill in AGENTS.md\n\n## Issue Tracking\n- Parent issue: #140\n- Sub-issues linked as true GitHub sub-issues: #146, #147, #148\n\n## Validation\n- dotnet build src/MauiApp/NdiForAndroid.csproj -f net10.0-android -c Debug -m:1 -v minimal\n- Installed updated APK on connected tablet\n\nCloses #140