### PR TITLE
fix(theme): System Default theme not applied when switching from Light [#230]

### DIFF
--- a/src/MauiApp/Features/Settings/Services/MauiAppearanceService.cs
+++ b/src/MauiApp/Features/Settings/Services/MauiAppearanceService.cs
@@ -29,16 +29,17 @@ public sealed class MauiAppearanceService : IAppearanceService
         if (Application.Current is null)
             return;
 
-        var isLight = theme == ThemeMode.Light
-            || (theme == ThemeMode.System
-                && Application.Current.RequestedTheme == AppTheme.Light);
-
+        // Set UserAppTheme first so that when theme == System, MAUI resolves
+        // RequestedTheme from the OS immediately — reading it before this call
+        // would return the previously-forced value (the bug: Light→System stays Light).
         Application.Current.UserAppTheme = theme switch
         {
             ThemeMode.Light => AppTheme.Light,
             ThemeMode.Dark  => AppTheme.Dark,
             _               => AppTheme.Unspecified,
         };
+
+        var isLight = Application.Current.RequestedTheme == AppTheme.Light;
 
         var palette = isLight ? LightPalette : DarkPalette;
         var accent  = ResolveAccent(accentColor);


### PR DESCRIPTION
## Root Cause

In \MauiAppearanceService.ApplyCore\, \isLight\ was computed **before** \UserAppTheme\ was set to \AppTheme.Unspecified\. When switching to System Default, \Application.Current.RequestedTheme\ still reflected the previously-forced value (Light), so the wrong palette was applied.

## Fix

Swap the order: set \UserAppTheme\ first, then read \RequestedTheme\.

\\\csharp
// BEFORE (buggy)
var isLight = theme == ThemeMode.Light
    || (theme == ThemeMode.System && Application.Current.RequestedTheme == AppTheme.Light);
Application.Current.UserAppTheme = theme switch { ... };

// AFTER (fixed)
Application.Current.UserAppTheme = theme switch { ... };   // set first
var isLight = Application.Current.RequestedTheme == AppTheme.Light; // now reads OS value
\\\

## Verified
- 109/109 unit tests passing
- Installed and launched on physical device (PID confirmed, crash buffer clean)

Fixes #230