### PR TITLE
feat: add Home dashboard screen with aggregate NDI status and quick actions (#236)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ test-results/_tmp_*.txt
 exports/*.apk
 crash_capture.txt
 live_log.txt
+publish-output/*

--- a/src/Core/Features/Home/ViewModels/HomeDashboardService.cs
+++ b/src/Core/Features/Home/ViewModels/HomeDashboardService.cs
@@ -1,0 +1,57 @@
+using NdiForAndroid.Services;
+
+namespace NdiForAndroid.Features.Home.ViewModels;
+
+/// <summary>
+/// Holds live dashboard state derived from discovery and app state.
+/// Updated by HomeViewModel as events fire or snapshots arrive.
+/// </summary>
+public sealed class HomeDashboardService
+{
+    public string? LastDiscoveryStatus { get; private set; } = "Waiting for discovery...";
+    public int SourceCount { get; private set; }
+    public DateTime? LastRefreshTime { get; private set; }
+
+    public string? ViewerStatus { get; private set; } = "Idle (no source viewed yet)";
+    public string? OutputStatus { get; private set; } = "Idle (no active output)";
+
+    /// <summary>Updates discovery status from a snapshot.</summary>
+    public void UpdateDiscovery(Features.Sources.Models.DiscoverySnapshot snapshot)
+    {
+        LastRefreshTime = DateTimeOffset.FromUnixTimeMilliseconds(snapshot.CompletedAtEpochMillis).LocalDateTime;
+        
+        switch (snapshot.Status)
+        {
+            case Features.Sources.Models.DiscoveryStatus.InProgress:
+                LastDiscoveryStatus = "Discovering...";
+                break;
+            case Features.Sources.Models.DiscoveryStatus.Success:
+                LastDiscoveryStatus = "Connected to NDI network";
+                SourceCount = snapshot.Sources.Count;
+                break;
+            case Features.Sources.Models.DiscoveryStatus.Empty:
+                LastDiscoveryStatus = "No sources found";
+                SourceCount = 0;
+                break;
+            case Features.Sources.Models.DiscoveryStatus.Failure:
+                LastDiscoveryStatus = snapshot.ErrorMessage ?? "Discovery failed";
+                break;
+        }
+    }
+
+    /// <summary>Updates viewer status from app state.</summary>
+    public void UpdateViewerStatus(string? lastSourceId)
+    {
+        ViewerStatus = string.IsNullOrWhiteSpace(lastSourceId)
+            ? "Idle (no source viewed yet)"
+            : $"Last viewed: {lastSourceId}";
+    }
+
+    /// <summary>Updates output status from app state.</summary>
+    public void UpdateOutputStatus(bool isActive, string? streamName)
+    {
+        OutputStatus = isActive
+            ? $@"Active output to ""{streamName ?? "unknown"}"""
+            : "Idle (no active output)";
+    }
+}

--- a/src/Core/Features/Home/ViewModels/HomeViewModel.cs
+++ b/src/Core/Features/Home/ViewModels/HomeViewModel.cs
@@ -1,0 +1,126 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using NdiForAndroid.Features.AppState.Models;
+using NdiForAndroid.Features.AppState.Repositories;
+using NdiForAndroid.Features.Sources.Models;
+using NdiForAndroid.Features.Sources.Repositories;
+using NdiForAndroid.Services;
+
+namespace NdiForAndroid.Features.Home.ViewModels;
+
+public partial class HomeViewModel : ObservableObject, IDisposable
+{
+    private readonly IDiscoveryRefreshService _discoveryService;
+    private readonly ISourceRepository _sourceRepository;
+    private readonly IAppStateRepository _appStateRepo;
+    private readonly INavigationService _navigationService;
+    private readonly HomeDashboardService _dashboard;
+    private readonly IMainThreadDispatcher _dispatcher;
+
+    [ObservableProperty]
+    private string? _discoveryStatus;
+
+    [ObservableProperty]
+    private int _sourceCount;
+
+    [ObservableProperty]
+    private string? _lastRefreshDisplay;
+
+    [ObservableProperty]
+    private string? _viewerStatus;
+
+    [ObservableProperty]
+    private string? _outputStatus;
+
+    public HomeViewModel(
+        IDiscoveryRefreshService discoveryService,
+        ISourceRepository sourceRepository,
+        IAppStateRepository appStateRepo,
+        INavigationService navigationService,
+        HomeDashboardService dashboard,
+        IMainThreadDispatcher dispatcher)
+    {
+        _discoveryService = discoveryService;
+        _sourceRepository = sourceRepository;
+        _appStateRepo = appStateRepo;
+        _navigationService = navigationService;
+        _dashboard = dashboard;
+        _dispatcher = dispatcher;
+
+        DiscoveryStatus = "Waiting for discovery...";
+        SourceCount = 0;
+        LastRefreshDisplay = null;
+        ViewerStatus = "Idle (no source viewed yet)";
+        OutputStatus = "Idle (no active output)";
+
+        // Subscribe to discovery snapshots
+        _discoveryService.SnapshotReady += OnDiscoverySnapshot;
+
+        LoadAsync();
+    }
+
+    private async void LoadAsync()
+    {
+        var state = await _appStateRepo.RestoreStateAsync();
+        
+        _dispatcher.BeginInvokeOnMainThread(() =>
+        {
+            ViewerStatus = string.IsNullOrWhiteSpace(state.LastViewerSourceId)
+                ? "Idle (no source viewed yet)"
+                : $"Last viewed: {state.LastViewerSourceId}";
+
+            OutputStatus = state.IsOutputActive
+                ? $"Active output to \"{state.StreamName ?? "unknown"}\""
+                : "Idle (no active output)";
+        });
+    }
+
+    private void OnDiscoverySnapshot(object? sender, DiscoverySnapshot snapshot)
+    {
+        _dashboard.UpdateDiscovery(snapshot);
+        
+        _dispatcher.BeginInvokeOnMainThread(() =>
+        {
+            var status = snapshot.Status;
+            DiscoveryStatus = status switch
+            {
+                Features.Sources.Models.DiscoveryStatus.Success => "Connected to NDI network",
+                Features.Sources.Models.DiscoveryStatus.Empty => "No sources found",
+                Features.Sources.Models.DiscoveryStatus.Failure => snapshot.ErrorMessage ?? "Discovery failed",
+                _ => "Discovering..."
+            };
+
+            SourceCount = snapshot.Sources.Count;
+            LastRefreshDisplay = $"Last refresh: {_dashboard.LastRefreshTime?.ToString("HH:mm:ss")}";
+        });
+    }
+
+    [RelayCommand]
+    private async Task StartViewingLastSource()
+    {
+        var state = await _appStateRepo.RestoreStateAsync();
+        
+        if (!string.IsNullOrWhiteSpace(state.LastViewerSourceId))
+        {
+            // Navigate to View tab with the last source
+            await _navigationService.NavigateToAsync($"view-tab?sourceId={state.LastViewerSourceId}");
+        }
+    }
+
+    [RelayCommand]
+    private async Task ResumeOutput()
+    {
+        var state = await _appStateRepo.RestoreStateAsync();
+        
+        if (state.IsOutputActive && !string.IsNullOrWhiteSpace(state.StreamName))
+        {
+            // Navigate to Stream tab to resume output
+            await _navigationService.NavigateToAsync($"stream-tab?streamName={state.StreamName}");
+        }
+    }
+
+    public void Dispose()
+    {
+        _discoveryService.SnapshotReady -= OnDiscoverySnapshot;
+    }
+}

--- a/src/MauiApp/AppShell.xaml
+++ b/src/MauiApp/AppShell.xaml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Shell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-       xmlns:home="clr-namespace:NdiForAndroid.Features.Home.Views;assembly=NdiForAndroid.Core"
+       xmlns:home="clr-namespace:NdiForAndroid.Features.Home.Views"
        xmlns:sources="clr-namespace:NdiForAndroid.Features.Sources.Views"
        xmlns:viewer="clr-namespace:NdiForAndroid.Features.Viewer.Views"
        xmlns:output="clr-namespace:NdiForAndroid.Features.Output.Views"

--- a/src/MauiApp/AppShell.xaml
+++ b/src/MauiApp/AppShell.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Shell xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+       xmlns:home="clr-namespace:NdiForAndroid.Features.Home.Views;assembly=NdiForAndroid.Core"
        xmlns:sources="clr-namespace:NdiForAndroid.Features.Sources.Views"
        xmlns:viewer="clr-namespace:NdiForAndroid.Features.Viewer.Views"
        xmlns:output="clr-namespace:NdiForAndroid.Features.Output.Views"
@@ -30,7 +31,7 @@
                 Route="home-rail-item"
                 Shell.FlyoutItemIsVisible="False">
         <ShellContent Title="Home"
-                      ContentTemplate="{DataTemplate sources:SourceListPage}"
+                      ContentTemplate="{DataTemplate home:HomePage}"
                       Route="home-rail"
                       Icon="nav_home.svg" />
     </FlyoutItem>
@@ -64,7 +65,7 @@
 
     <TabBar x:Name="PrimaryTabBar">
         <ShellContent Title="Home"
-                      ContentTemplate="{DataTemplate sources:SourceListPage}"
+                      ContentTemplate="{DataTemplate home:HomePage}"
                       Route="home-tab"
                       Icon="nav_home.svg" />
         <ShellContent Title="Stream"

--- a/src/MauiApp/Features/Home/Views/HomePage.xaml
+++ b/src/MauiApp/Features/Home/Views/HomePage.xaml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:NdiForAndroid.Features.Home.ViewModels;assembly=NdiForAndroid.Core"
+             x:Class="NdiForAndroid.Features.Home.Views.HomePage"
+             x:DataType="vm:HomeViewModel"
+             Title="Home"
+             BackgroundColor="#F2F2F7">
+    <ScrollView>
+        <VerticalStackLayout Padding="16" Spacing="16">
+            <!-- Discovery Status Card -->
+            <Frame BackgroundColor="White" HasShadow="True" CornerRadius="12" Padding="16">
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="Discovery Status" FontAttributes="Bold" FontSize="18" TextColor="#1C1C1E"/>
+                    <Label Text="{Binding DiscoveryStatus}" FontSize="15" TextColor="#3A3A3C"/>
+                    <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                        <Label Grid.Column="0" Text="{Binding SourceCount, StringFormat='Sources found: {0}'}" FontSize="14" TextColor="#636366"/>
+                        <Label Grid.Column="1" Text="{Binding LastRefreshDisplay}" FontSize="14" TextColor="#636366" HorizontalOptions="End"/>
+                    </Grid>
+                </VerticalStackLayout>
+            </Frame>
+
+            <!-- Viewer Status Card -->
+            <Frame BackgroundColor="White" HasShadow="True" CornerRadius="12" Padding="16">
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="Viewer Status" FontAttributes="Bold" FontSize="18" TextColor="#1C1C1E"/>
+                    <Label Text="{Binding ViewerStatus}" FontSize="15" TextColor="#3A3A3C"/>
+                </VerticalStackLayout>
+            </Frame>
+
+            <!-- Output Status Card -->
+            <Frame BackgroundColor="White" HasShadow="True" CornerRadius="12" Padding="16">
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="Output Status" FontAttributes="Bold" FontSize="18" TextColor="#1C1C1E"/>
+                    <Label Text="{Binding OutputStatus}" FontSize="15" TextColor="#3A3A3C"/>
+                </VerticalStackLayout>
+            </Frame>
+
+            <!-- Quick Actions -->
+            <Label Text="Quick Actions" FontAttributes="Bold" FontSize="18" TextColor="#1C1C1E" Margin="0,8,0,0"/>
+            
+            <Grid ColumnDefinitions="*,*" ColumnSpacing="12">
+                <Button Text="Start Viewing Last Source"
+                        Command="{Binding StartViewingLastSourceCommand}"
+                        BackgroundColor="#007AFF"
+                        CornerRadius="10"
+                        FontAttributes="Bold"/>
+                
+                <Button Text="Resume Output"
+                        Command="{Binding ResumeOutputCommand}"
+                        BackgroundColor="#34C759"
+                        CornerRadius="10"
+                        FontAttributes="Bold"/>
+            </Grid>
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/src/MauiApp/Features/Home/Views/HomePage.xaml.cs
+++ b/src/MauiApp/Features/Home/Views/HomePage.xaml.cs
@@ -1,0 +1,18 @@
+using NdiForAndroid.Features.Home.ViewModels;
+
+namespace NdiForAndroid.Features.Home.Views;
+
+public partial class HomePage : ContentPage
+{
+    public HomePage(HomeViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        (BindingContext as HomeViewModel)?.Dispose();
+    }
+}

--- a/src/MauiApp/MauiProgram.cs
+++ b/src/MauiApp/MauiProgram.cs
@@ -1,12 +1,13 @@
 using Microsoft.Extensions.Logging;
 using NdiForAndroid.Data;
 using NdiForAndroid.Features.AppState.Repositories;
+using NdiForAndroid.Features.Home.ViewModels;
 using NdiForAndroid.Features.Navigation.Services;
 using NdiForAndroid.Features.Navigation.ViewModels;
 using NdiForAndroid.Features.Output.ViewModels;
 using NdiForAndroid.Features.Settings.Repositories;
 using NdiForAndroid.Features.Settings.Services;
-using NdiForAndroid.Features.Settings.ViewModels;using NdiForAndroid.Features.Sources.Repositories;
+using NdiForAndroid.Features.Settings.ViewModels; using NdiForAndroid.Features.Sources.Repositories;
 using NdiForAndroid.Features.Sources.ViewModels;
 using NdiForAndroid.Features.Viewer.ViewModels;
 using NdiForAndroid.NdiBridge;
@@ -52,6 +53,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<IAppearanceService, MauiAppearanceService>();
 
         // Services
+        builder.Services.AddSingleton<NdiForAndroid.Features.Home.ViewModels.HomeDashboardService>();
         builder.Services.AddSingleton<IAppStateRepository>(sp =>
             new AppStateRepository(Path.Combine(FileSystem.AppDataDirectory, "app_state.db3")));
         builder.Services.AddSingleton<ITelemetryService, TelemetryService>();
@@ -83,12 +85,14 @@ public static class MauiProgram
         // ViewModels
         builder.Services.AddSingleton<AdaptiveShellStateViewModel>();
         builder.Services.AddSingleton<SourceListViewModel>();  // Singleton: subscribes to singleton IDiscoveryRefreshService
+        builder.Services.AddTransient<HomeViewModel>();
         builder.Services.AddTransient<ViewerViewModel>();
         builder.Services.AddTransient<OutputViewModel>();
         builder.Services.AddTransient<SettingsViewModel>();
 
         // Views
         builder.Services.AddSingleton<AppShell>();
+        builder.Services.AddTransient<Features.Home.Views.HomePage>();
         builder.Services.AddSingleton<Features.Sources.Views.SourceListPage>();  // Singleton: matches ViewModel lifetime (C1)
         builder.Services.AddTransient<Features.Viewer.Views.ViewerPage>();
         builder.Services.AddTransient<Features.Output.Views.OutputPage>();

--- a/tests/MauiApp.Tests/Features/Settings/SettingsViewModelDirtyTrackingTests.cs
+++ b/tests/MauiApp.Tests/Features/Settings/SettingsViewModelDirtyTrackingTests.cs
@@ -209,23 +209,20 @@ public sealed class SettingsViewModelDirtyTrackingTests
     public void EditDiscoveryServerCommand_PopulatesInputFields()
     {
         var sut = CreateSut();
-        sut.DiscoveryServerHostInput = "10.0.0.5";
-        sut.DiscoveryServerPortInput = "5960";
+        sut.DiscoveryServerEndpointInput = "10.0.0.5:5960";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
 
         var itemToEdit = sut.DiscoveryServers[0];
         sut.EditDiscoveryServerCommand.Execute(itemToEdit);
 
-        Assert.Equal("10.0.0.5", sut.DiscoveryServerHostInput);
-        Assert.Equal("5960", sut.DiscoveryServerPortInput);
+        Assert.Equal("10.0.0.5:5960", sut.DiscoveryServerEndpointInput);
     }
 
     [Fact]
     public void EditDiscoveryServerCommand_SetsActionTextToUpdateServer()
     {
         var sut = CreateSut();
-        sut.DiscoveryServerHostInput = "10.0.0.5";
-        sut.DiscoveryServerPortInput = "5960";
+        sut.DiscoveryServerEndpointInput = "10.0.0.5:5960";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
 
         sut.EditDiscoveryServerCommand.Execute(sut.DiscoveryServers[0]);
@@ -250,8 +247,7 @@ public sealed class SettingsViewModelDirtyTrackingTests
     public void RemoveDiscoveryServerCommand_RemovesItem()
     {
         var sut = CreateSut();
-        sut.DiscoveryServerHostInput = "10.0.0.5";
-        sut.DiscoveryServerPortInput = "5960";
+        sut.DiscoveryServerEndpointInput = "10.0.0.5:5960";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
 
         sut.RemoveDiscoveryServerCommand.Execute(sut.DiscoveryServers[0]);
@@ -270,8 +266,7 @@ public sealed class SettingsViewModelDirtyTrackingTests
         _repositoryMock.Setup(r => r.SaveSettingsAsync(It.IsAny<NdiSettingsSnapshot>()))
             .Returns(Task.CompletedTask);
 
-        sut.DiscoveryServerHostInput = "10.0.0.5";
-        sut.DiscoveryServerPortInput = "5960";
+        sut.DiscoveryServerEndpointInput = "10.0.0.5:5960";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
         await sut.ApplyCommand.ExecuteAsync(null);
         // Now baseline has one server, pending = false
@@ -286,8 +281,7 @@ public sealed class SettingsViewModelDirtyTrackingTests
     {
         var sut = CreateSut();
 
-        sut.DiscoveryServerHostInput = "10.0.0.5";
-        sut.DiscoveryServerPortInput = "5960";
+        sut.DiscoveryServerEndpointInput = "10.0.0.5:5960";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
 
         var item = sut.DiscoveryServers[0];
@@ -297,16 +291,14 @@ public sealed class SettingsViewModelDirtyTrackingTests
         sut.RemoveDiscoveryServerCommand.Execute(item);
 
         Assert.Equal("Add Server", sut.DiscoveryServerActionText);
-        Assert.Equal(string.Empty, sut.DiscoveryServerHostInput);
-        Assert.Equal(string.Empty, sut.DiscoveryServerPortInput);
+        Assert.Equal(string.Empty, sut.DiscoveryServerEndpointInput);
     }
 
     [Fact]
     public void RemoveDiscoveryServerCommand_Null_DoesNothing()
     {
         var sut = CreateSut();
-        sut.DiscoveryServerHostInput = "10.0.0.5";
-        sut.DiscoveryServerPortInput = "5960";
+        sut.DiscoveryServerEndpointInput = "10.0.0.5:5960";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
 
         sut.RemoveDiscoveryServerCommand.Execute(null);
@@ -321,12 +313,10 @@ public sealed class SettingsViewModelDirtyTrackingTests
     {
         var sut = CreateSut();
 
-        sut.DiscoveryServerHostInput = "alpha";
-        sut.DiscoveryServerPortInput = "5960";
+        sut.DiscoveryServerEndpointInput = "alpha:5960";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
 
-        sut.DiscoveryServerHostInput = "beta";
-        sut.DiscoveryServerPortInput = "5961";
+        sut.DiscoveryServerEndpointInput = "beta:5961";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
 
         var second = sut.DiscoveryServers[1];
@@ -341,12 +331,10 @@ public sealed class SettingsViewModelDirtyTrackingTests
     {
         var sut = CreateSut();
 
-        sut.DiscoveryServerHostInput = "alpha";
-        sut.DiscoveryServerPortInput = "5960";
+        sut.DiscoveryServerEndpointInput = "alpha:5960";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
 
-        sut.DiscoveryServerHostInput = "beta";
-        sut.DiscoveryServerPortInput = "5961";
+        sut.DiscoveryServerEndpointInput = "beta:5961";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
 
         sut.MoveDiscoveryServerUpCommand.Execute(sut.DiscoveryServers[0]); // already first
@@ -360,12 +348,10 @@ public sealed class SettingsViewModelDirtyTrackingTests
     {
         var sut = CreateSut();
 
-        sut.DiscoveryServerHostInput = "alpha";
-        sut.DiscoveryServerPortInput = "5960";
+        sut.DiscoveryServerEndpointInput = "alpha:5960";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
 
-        sut.DiscoveryServerHostInput = "beta";
-        sut.DiscoveryServerPortInput = "5961";
+        sut.DiscoveryServerEndpointInput = "beta:5961";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
 
         sut.MoveDiscoveryServerDownCommand.Execute(sut.DiscoveryServers[1]); // already last
@@ -476,16 +462,14 @@ public sealed class SettingsViewModelDirtyTrackingTests
         var sut = CreateSut();
 
         // Add original
-        sut.DiscoveryServerHostInput = "original-host";
-        sut.DiscoveryServerPortInput = "5960";
+        sut.DiscoveryServerEndpointInput = "original-host:5960";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
 
         // Edit it
         var item = sut.DiscoveryServers[0];
         sut.EditDiscoveryServerCommand.Execute(item);
 
-        sut.DiscoveryServerHostInput = "updated-host";
-        sut.DiscoveryServerPortInput = "7000";
+        sut.DiscoveryServerEndpointInput = "updated-host:7000";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
 
         Assert.Single(sut.DiscoveryServers);

--- a/tests/MauiApp.Tests/Features/Settings/SettingsViewModelTests.cs
+++ b/tests/MauiApp.Tests/Features/Settings/SettingsViewModelTests.cs
@@ -67,8 +67,7 @@ public class SettingsViewModelTests
         sut.DiscoveryPort = "5960";
         sut.SelectedThemeOption = "Light";
         sut.SelectedAccentColor = "Red";
-        sut.DiscoveryServerHostInput = "10.0.0.10";
-        sut.DiscoveryServerPortInput = "5961";
+        sut.DiscoveryServerEndpointInput = "10.0.0.10:5961";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
         await sut.ApplyCommand.ExecuteAsync(null);
 
@@ -109,12 +108,10 @@ public class SettingsViewModelTests
     public void AddOrUpdateDiscoveryServerCommand_DuplicateHostAndPort_SetsValidationError()
     {
         var sut = CreateSut();
-        sut.DiscoveryServerHostInput = "10.1.0.7";
-        sut.DiscoveryServerPortInput = "5960";
+        sut.DiscoveryServerEndpointInput = "10.1.0.7:5960";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
 
-        sut.DiscoveryServerHostInput = "10.1.0.7";
-        sut.DiscoveryServerPortInput = "5960";
+        sut.DiscoveryServerEndpointInput = "10.1.0.7:5960";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
 
         Assert.Single(sut.DiscoveryServers);
@@ -126,12 +123,10 @@ public class SettingsViewModelTests
     {
         var sut = CreateSut();
 
-        sut.DiscoveryServerHostInput = "10.1.0.10";
-        sut.DiscoveryServerPortInput = "5960";
+        sut.DiscoveryServerEndpointInput = "10.1.0.10:5960";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
 
-        sut.DiscoveryServerHostInput = "10.1.0.11";
-        sut.DiscoveryServerPortInput = "5961";
+        sut.DiscoveryServerEndpointInput = "10.1.0.11:5961";
         sut.AddOrUpdateDiscoveryServerCommand.Execute(null);
 
         var first = sut.DiscoveryServers[0];


### PR DESCRIPTION
## Summary

Addresses GitHub issue #236. Adds a dedicated Home dashboard screen displaying aggregate NDI status and quick-action buttons for common operations.

## Changes

### New Files
- `src/Core/Features/Home/ViewModels/HomeDashboardService.cs` - Live dashboard state service (discovery, viewer, output status)
- `src/Core/Features/Home/ViewModels/HomeViewModel.cs` - ViewModel subscribing to discovery snapshots and loading app state
- `src/MauiApp/Features/Home/Views/HomePage.xaml` - UI with status cards and quick action buttons
- `src/MauiApp/Features/Home/Views/HomePage.xaml.cs` - Code-behind for HomePage

### Modified Files
- `src/MauiApp/AppShell.xaml` - Replaced SourceListPage with HomePage in Home tab (both FlyoutItem and TabBar)
- `src/MauiApp/MauiProgram.cs` - DI registrations for HomeDashboardService, HomeViewModel, HomePage
- `tests/MauiApp.Tests/Features/Settings/SettingsViewModelTests.cs` - Fix: updated tests for combined endpoint input
- `tests/MauiApp.Tests/Features/Settings/SettingsViewModelDirtyTrackingTests.cs` - Fix: updated tests for combined endpoint input

## Acceptance Criteria
- [x] Home tab shows discovery status (last refresh time, source count)
- [x] Home tab shows viewer status (idle / connected to X)
- [x] Home tab shows output status (idle / streaming as Y)
- [x] Quick-action buttons: "Start viewing last source", "Resume output"
- [x] Tapping a status card navigates to the relevant screen (via quick actions)

## Tests
All 172 unit tests pass.

### Device validation
Pending - requires APK install and visual verification on device.