### PR TITLE
Register ndi:// URI scheme for external deep linking

### DIFF
--- a/src/Core/Features/DeepLinking/Services/IDeepLinkService.cs
+++ b/src/Core/Features/DeepLinking/Services/IDeepLinkService.cs
@@ -1,0 +1,35 @@
+using NdiForAndroid.NdiBridge;
+
+namespace NdiForAndroid.Features.DeepLinking.Services;
+
+/// <summary>
+/// Parses ndi:// deep links and routes them to the appropriate app feature.
+/// </summary>
+public interface IDeepLinkService
+{
+    /// <summary>
+    /// Parses and applies an ndi:// URI deep link.
+    /// Routes naviagtion based on scheme + path:
+    /// - ndi://view?sourceId=xxx → navigate to Viewer page for that source
+    /// - ndi://stream?sourceId=xxx → navigate to Output page in re-stream mode for that source
+    /// </summary>
+    Task<bool> ProcessDeepLinkAsync(string uriString);
+
+    /// <summary>
+    /// Returns an error message if the URI could not be processed, or null on success.
+    /// </summary>
+    string? LastErrorMessage { get; }
+}
+
+/// <summary>Represents a parsed ndi:// deep link.</summary>
+public record NdiDeepLink(
+    DeepLinkType Type,
+    string SourceId,
+    QualityProfile QualityProfile = QualityProfile.Balanced);
+
+/// <summary>Type of ndi:// deep link action.</summary>
+public enum DeepLinkType
+{
+    View,    // Open viewer for a source
+    Stream,  // Start re-streaming a source
+}

--- a/src/MauiApp/Features/DeepLinking/DeepLinkService.cs
+++ b/src/MauiApp/Features/DeepLinking/DeepLinkService.cs
@@ -53,7 +53,7 @@ public sealed class DeepLinkService : IDeepLinkService
             }
 
             // Check that the source exists in our cached discovery list
-            var sourceRepo = _serviceProvider.GetService<Core.Features.Sources.Repositories.ISourceRepository>();
+            var sourceRepo = _serviceProvider.GetService<NdiForAndroid.Features.Sources.Repositories.ISourceRepository>();
             if (sourceRepo != null)
             {
                 var cachedSources = await sourceRepo.GetCachedSourcesAsync();

--- a/src/MauiApp/Features/DeepLinking/DeepLinkService.cs
+++ b/src/MauiApp/Features/DeepLinking/DeepLinkService.cs
@@ -1,0 +1,119 @@
+using NdiForAndroid.Features.DeepLinking.Services;
+using NdiForAndroid.NdiBridge;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace NdiForAndroid.Features.DeepLinking;
+
+/// <summary>
+/// Deep link handler that parses ndi:// URIs and routes to the appropriate feature.
+/// </summary>
+public sealed class DeepLinkService : IDeepLinkService
+{
+    private readonly IShellNavigationService _navigation;
+    private readonly IServiceProvider _serviceProvider;
+    private string? _lastErrorMessage;
+
+    public string? LastErrorMessage => _lastErrorMessage;
+
+    public DeepLinkService(IShellNavigationService navigation, IServiceProvider serviceProvider)
+    {
+        _navigation = navigation;
+        _serviceProvider = serviceProvider;
+    }
+
+    public async Task<bool> ProcessDeepLinkAsync(string uriString)
+    {
+        _lastErrorMessage = null;
+
+        if (string.IsNullOrWhiteSpace(uriString))
+        {
+            _lastErrorMessage = "Invalid deep link: empty URI.";
+            return false;
+        }
+
+        try
+        {
+            var uri = new Uri(uriString);
+
+            if (!string.Equals(uri.Scheme, "ndi", StringComparison.OrdinalIgnoreCase))
+            {
+                _lastErrorMessage = $"Unsupported scheme '{uri.Scheme}'. Expected 'ndi://'.";
+                return false;
+            }
+
+            var path = uri.AbsolutePath.TrimStart('/');
+            var query = uri.Query.TrimStart('?');
+            var sourceId = ParseQueryString(query, "sourceId");
+
+            if (string.IsNullOrWhiteSpace(sourceId))
+            {
+                _lastErrorMessage = "Invalid deep link: missing 'sourceId' parameter.";
+                return false;
+            }
+
+            // Check that the source exists in our cached discovery list
+            var sourceRepo = _serviceProvider.GetService<Core.Features.Sources.Repositories.ISourceRepository>();
+            if (sourceRepo != null)
+            {
+                var cachedSources = await sourceRepo.GetCachedSourcesAsync();
+                var matched = cachedSources.Any(s => s.SourceId.Equals(sourceId, StringComparison.OrdinalIgnoreCase));
+
+                // Also match by display name for convenience
+                if (!matched)
+                {
+                    var foundByDisplayName = cachedSources.FirstOrDefault(s =>
+                        s.DisplayName?.IndexOf(sourceId, StringComparison.OrdinalIgnoreCase) >= 0);
+
+                    if (foundByDisplayName != null)
+                        sourceId = foundByDisplayName.SourceId;
+                }
+            }
+
+            // Route based on path segment
+            switch (path.ToLowerInvariant())
+            {
+                case "view":
+                    await NavigateToViewerAsync(sourceId);
+                    return true;
+
+                case "stream":
+                    await NavigateToOutputForReStreamAsync(sourceId);
+                    return true;
+
+                default:
+                    _lastErrorMessage = $"Unknown action '{path}'. Use 'view' or 'stream'.";
+                    return false;
+            }
+        }
+        catch (UriFormatException)
+        {
+            _lastErrorMessage = "Invalid deep link: malformed URI.";
+            return false;
+        }
+    }
+
+    private async Task NavigateToViewerAsync(string sourceId)
+    {
+        // Navigate to the viewer page and set the selected source
+        await _navigation.NavigateAsync($"//viewer?sourceId={Uri.EscapeDataString(sourceId)}");
+    }
+
+    private async Task NavigateToOutputForReStreamAsync(string sourceId)
+    {
+        // Navigate to the output page in re-stream mode with the source ID pre-set
+        await _navigation.NavigateAsync($"//output?reStreamSourceId={Uri.EscapeDataString(sourceId)}&isReStreamMode=true");
+    }
+
+    private static string? ParseQueryString(string query, string key)
+    {
+        if (string.IsNullOrEmpty(query)) return null;
+
+        foreach (var pair in query.Split('&'))
+        {
+            var parts = pair.Split('=', 2);
+            if (parts.Length == 2 && parts[0] == key)
+                return Uri.UnescapeDataString(parts[1]);
+        }
+        return null;
+    }
+}

--- a/src/MauiApp/Features/DeepLinking/DeepLinkService.cs
+++ b/src/MauiApp/Features/DeepLinking/DeepLinkService.cs
@@ -1,6 +1,7 @@
 using NdiForAndroid.Features.DeepLinking.Services;
 using NdiForAndroid.NdiBridge;
 using Microsoft.Extensions.DependencyInjection;
+using NdiForAndroid.Services;
 
 namespace NdiForAndroid.Features.DeepLinking;
 
@@ -9,13 +10,13 @@ namespace NdiForAndroid.Features.DeepLinking;
 /// </summary>
 public sealed class DeepLinkService : IDeepLinkService
 {
-    private readonly IShellNavigationService _navigation;
+    private readonly INavigationService _navigation;
     private readonly IServiceProvider _serviceProvider;
     private string? _lastErrorMessage;
 
     public string? LastErrorMessage => _lastErrorMessage;
 
-    public DeepLinkService(IShellNavigationService navigation, IServiceProvider serviceProvider)
+    public DeepLinkService(INavigationService navigation, IServiceProvider serviceProvider)
     {
         _navigation = navigation;
         _serviceProvider = serviceProvider;
@@ -95,13 +96,13 @@ public sealed class DeepLinkService : IDeepLinkService
     private async Task NavigateToViewerAsync(string sourceId)
     {
         // Navigate to the viewer page and set the selected source
-        await _navigation.NavigateAsync($"//viewer?sourceId={Uri.EscapeDataString(sourceId)}");
+        await _navigation.NavigateToAsync($"//viewer?sourceId={Uri.EscapeDataString(sourceId)}");
     }
 
     private async Task NavigateToOutputForReStreamAsync(string sourceId)
     {
         // Navigate to the output page in re-stream mode with the source ID pre-set
-        await _navigation.NavigateAsync($"//output?reStreamSourceId={Uri.EscapeDataString(sourceId)}&isReStreamMode=true");
+        await _navigation.NavigateToAsync($"//output?reStreamSourceId={Uri.EscapeDataString(sourceId)}&isReStreamMode=true");
     }
 
     private static string? ParseQueryString(string query, string key)

--- a/src/MauiApp/MauiProgram.cs
+++ b/src/MauiApp/MauiProgram.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Logging;
 using NdiForAndroid.Data;
 using NdiForAndroid.Features.AppState.Repositories;
+using NdiForAndroid.Features.ConnectionHistory;
+using NdiForAndroid.Features.DeepLinking;
 using NdiForAndroid.Features.Home.ViewModels;
 using NdiForAndroid.Features.Navigation.Services;
 using NdiForAndroid.Features.Navigation.ViewModels;
@@ -56,6 +58,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<NdiForAndroid.Features.Home.ViewModels.HomeDashboardService>();
         builder.Services.AddSingleton<IAppStateRepository>(sp =>
             new AppStateRepository(Path.Combine(FileSystem.AppDataDirectory, "app_state.db3")));
+        builder.Services.AddSingleton<IDeepLinkService, DeepLinkService>();
         builder.Services.AddSingleton<ITelemetryService, TelemetryService>();
         builder.Services.AddSingleton<INavigationService, ShellNavigationService>();
         builder.Services.AddSingleton<INavigationPolicyService, NavigationPolicyService>();

--- a/src/MauiApp/MauiProgram.cs
+++ b/src/MauiApp/MauiProgram.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using NdiForAndroid.Data;
 using NdiForAndroid.Features.AppState.Repositories;
 using NdiForAndroid.Features.DeepLinking;
+using NdiForAndroid.Features.DeepLinking.Services;
 using NdiForAndroid.Features.Home.ViewModels;
 using NdiForAndroid.Features.Navigation.Services;
 using NdiForAndroid.Features.Navigation.ViewModels;

--- a/src/MauiApp/MauiProgram.cs
+++ b/src/MauiApp/MauiProgram.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Logging;
 using NdiForAndroid.Data;
 using NdiForAndroid.Features.AppState.Repositories;
-using NdiForAndroid.Features.ConnectionHistory;
 using NdiForAndroid.Features.DeepLinking;
 using NdiForAndroid.Features.Home.ViewModels;
 using NdiForAndroid.Features.Navigation.Services;
@@ -9,7 +8,8 @@ using NdiForAndroid.Features.Navigation.ViewModels;
 using NdiForAndroid.Features.Output.ViewModels;
 using NdiForAndroid.Features.Settings.Repositories;
 using NdiForAndroid.Features.Settings.Services;
-using NdiForAndroid.Features.Settings.ViewModels; using NdiForAndroid.Features.Sources.Repositories;
+using NdiForAndroid.Features.Settings.ViewModels;
+using NdiForAndroid.Features.Sources.Repositories;
 using NdiForAndroid.Features.Sources.ViewModels;
 using NdiForAndroid.Features.Viewer.ViewModels;
 using NdiForAndroid.NdiBridge;

--- a/src/MauiApp/Platforms/Android/MainActivity.cs
+++ b/src/MauiApp/Platforms/Android/MainActivity.cs
@@ -1,10 +1,12 @@
 using Android.App;
+using Android.Content;
 using Android.OS;
 using Android.Content.Res;
 using Android.Content.PM;
 using AndroidX.Core.View;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
+using NdiForAndroid.Features.DeepLinking;
 using NdiForAndroid.Features.Settings.Services;
 using NdiForAndroid.Services;
 
@@ -18,11 +20,23 @@ namespace NdiForAndroid;
     LaunchMode = LaunchMode.SingleTop,
     ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode |
                            ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[IntentFilter(
+    new[] { Intent.ActionView },
+    Categories = new[] { Intent.CategoryDefault, Intent.CategoryBrowsable },
+    DataScheme = "ndi",
+    DataHost = "*")]
 public class MainActivity : MauiAppCompatActivity
 {
     protected override void OnCreate(Bundle? savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
+
+        // Check if launched from a deep link on startup
+        var launchIntent = Intent?.Data;
+        if (launchIntent != null && string.Equals(launchIntent.Scheme, "ndi", StringComparison.OrdinalIgnoreCase))
+        {
+            HandleDeepLinkAsync(launchIntent.ToString()).ConfigureAwait(continueOnCapturedContext: false);
+        }
 
         // Allow the app to draw behind the status bar so Shell chrome and
         // the status bar background are seamless across the full screen width.
@@ -35,6 +49,46 @@ public class MainActivity : MauiAppCompatActivity
         }
 
         SyncNavigationOrientation();
+    }
+
+    protected override void OnNewIntent(Intent intent)
+    {
+        base.OnNewIntent(intent);
+
+        // Process ndi:// deep links from external apps or shortcuts
+        var data = intent?.Data;
+        if (data != null && string.Equals(data.Scheme, "ndi", StringComparison.OrdinalIgnoreCase))
+        {
+            HandleDeepLinkAsync(data.ToString()).ConfigureAwait(continueOnCapturedContext: false);
+        }
+    }
+
+    private async void HandleDeepLinkAsync(string uriString)
+    {
+        try
+        {
+            var deepLinkService = IPlatformApplication.Current?.Services.GetService<IDeepLinkService>();
+            if (deepLinkService == null)
+            {
+                await MainThread.InvokeOnMainThreadAsync(() =>
+                    Microsoft.Maui.ApplicationModel.Platform.CurrentActivity?.RunOnUiThread(() =>
+                        Android.Widget.Toast.MakeText(Microsoft.Maui.ApplicationModel.Platform.CurrentActivity, "Deep link service unavailable.", Android.Widget.ToastLength.Long).Show()));
+                return;
+            }
+
+            var success = await deepLinkService.ProcessDeepLinkAsync(uriString);
+            if (success) return;
+
+            // Show error message
+            var msg = deepLinkService.LastErrorMessage ?? "Unknown deep link error.";
+            await MainThread.InvokeOnMainThreadAsync(() =>
+                Android.Widget.Toast.MakeText(Microsoft.Maui.ApplicationModel.Platform.CurrentActivity, msg, Android.Widget.ToastLength.Long).Show());
+        }
+        catch (Exception ex)
+        {
+            await MainThread.InvokeOnMainThreadAsync(() =>
+                Android.Widget.Toast.MakeText(Microsoft.Maui.ApplicationModel.Platform.CurrentActivity, $"Deep link error: {ex.Message}", Android.Widget.ToastLength.Long).Show());
+        }
     }
 
     protected override void OnResume()

--- a/src/MauiApp/Platforms/Android/MainActivity.cs
+++ b/src/MauiApp/Platforms/Android/MainActivity.cs
@@ -7,6 +7,7 @@ using AndroidX.Core.View;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
 using NdiForAndroid.Features.DeepLinking;
+using NdiForAndroid.Features.DeepLinking.Services;
 using NdiForAndroid.Features.Settings.Services;
 using NdiForAndroid.Services;
 
@@ -63,7 +64,7 @@ public class MainActivity : MauiAppCompatActivity
         }
     }
 
-    private async void HandleDeepLinkAsync(string uriString)
+    private async Task HandleDeepLinkAsync(string uriString)
     {
         try
         {


### PR DESCRIPTION
Closes #239

## Summary

Registers an 
di:// URI scheme intent filter on the Android app, enabling external apps and shortcuts to deep-link directly into viewing or re-streaming a specific NDI source.

## Changes

### Intent Registration (MainActivity.cs)
- Added [IntentFilter] attribute: matches 
di://* URIs with ACTION_VIEW + CATEGORY_DEFAULT + CATEGORY_BROWSABLE
- Launch mode SingleTop supports both cold-start and in-app navigation

### Deep Link Handling
| URI Pattern | Action |
|---|---|
| 
di://view?sourceId=xxx | Navigate to Viewer page for that source |
| 
di://stream?sourceId=xxx | Navigate to Output page with re-stream mode + pre-set source ID |

### Error Handling
- Invalid/missing scheme → toast: *'Unsupported scheme'*
- Missing sourceId parameter → toast: *'Invalid deep link: missing sourceId'*
- Unsupported path → toast: *'Unknown action. Use view or stream'*
- Malformed URI → toast: *'Invalid deep link: malformed URI'*

### DeepLinkService (Core + MauiApp)
- IDeepLinkService interface with ProcessDeepLinkAsync(uriString) method
- Validates and parses ndi:// URIs, resolves source from cached discovery list (ID or displayName fallback)
- Handles both cold-start (OnCreate) and in-app launch (OnNewIntent) deep links

### AndroidManifest
- Intent filter added via C# attribute (no manifest XML changes needed) — handles 
di://* scheme