### PR TITLE
fix(#143): unify app state into the shared ndi.db3 database

### DIFF
--- a/src/Core/Features/AppState/Repositories/AppStateRepository.cs
+++ b/src/Core/Features/AppState/Repositories/AppStateRepository.cs
@@ -1,11 +1,12 @@
-using SQLite;
 using NdiForAndroid.Features.AppState.Models;
+using SQLite;
 
 namespace NdiForAndroid.Features.AppState.Repositories;
 
 /// <summary>
 /// Key-value persistence for app state that survives backgrounding and process death.
-/// Accepts a constructor parameter for the database file path so it doesn't depend on any MAUI-specific APIs.
+/// Writes to the same shared database file as NdiDatabase (ndi.db3) so all data
+/// lives in a single file — no split persistence across multiple DB files.
 /// </summary>
 public sealed class AppStateRepository : IDisposable, IAppStateRepository
 {
@@ -21,13 +22,15 @@ public sealed class AppStateRepository : IDisposable, IAppStateRepository
         public string Value { get; set; } = string.Empty;
     }
 
+    /// <summary>
+    /// Creates an AppStateRepository that writes to the same database file as NdiDatabase.
+    /// The path should be constructed to match NdiDatabase's database path: FileSystem.AppDataDirectory/ndi.db3
+    /// </summary>
     public AppStateRepository(string databasePath)
     {
         _connection = new SQLiteAsyncConnection(databasePath);
         _initTask = _connection.CreateTableAsync<KeyValueEntity>();
     }
-
-    private Task EnsureInitialized() => _initTask;
 
     public void Dispose()
     {
@@ -57,6 +60,8 @@ public sealed class AppStateRepository : IDisposable, IAppStateRepository
             isOutputActive == "true",
             string.IsNullOrEmpty(lastSelected) ? null : lastSelected);
     }
+
+    private async Task EnsureInitialized() => await _initTask;
 
     private async Task SetKey(string key, string value)
     {

--- a/src/MauiApp/Data/NdiDatabase.cs
+++ b/src/MauiApp/Data/NdiDatabase.cs
@@ -1,10 +1,21 @@
 using SQLite;
+using NdiForAndroid.Features.AppState.Models;
 using NdiForAndroid.Features.Sources.Models;
 using NdiForAndroid.Features.Settings.Models;
 using NdiForAndroid.NdiBridge;
 using System.Text.Json;
 
 namespace NdiForAndroid.Data;
+
+/// <summary>
+/// Key-value entity used for persisting application state.
+/// </summary>
+[Table("app_state")]
+internal sealed class KeyValueEntity
+{
+    [PrimaryKey] public string Key { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+}
 
 [Table("sources")]
 public class SourceEntity
@@ -118,14 +129,23 @@ public sealed class NdiDatabase
     private readonly Task _initTask;
 
     public NdiDatabase()
+        : this(Path.Combine(FileSystem.AppDataDirectory, "ndi.db3"))
     {
-        var dbPath = Path.Combine(FileSystem.AppDataDirectory, "ndi.db3");
+    }
+
+    /// <summary>
+    /// Creates an NdiDatabase instance pointing to a specific file path.
+    /// Internal constructor used by tests for isolation.
+    /// </summary>
+    internal NdiDatabase(string dbPath)
+    {
         _connection = new SQLiteAsyncConnection(dbPath);
         _initTask = InitAsync();
     }
 
     public async Task InitAsync()
     {
+        await _connection.CreateTableAsync<KeyValueEntity>();
         await _connection.CreateTableAsync<SourceEntity>();
         await _connection.CreateTableAsync<SettingsEntity>();
         await _connection.CreateTableAsync<ViewerSessionEntity>();
@@ -136,11 +156,70 @@ public sealed class NdiDatabase
         await _connection.CreateTableAsync<DiscoveryServerCheckStatusEntity>();
         await _connection.CreateTableAsync<CachedSourceCrossrefEntity>();
         await _connection.CreateTableAsync<ConnectionHistoryEntity>();
+        await EnsureAppStateColumnsAsync();
         await EnsureSettingsColumnsAsync();
         await EnsureSourceColumnsAsync();
     }
 
     private Task EnsureInitializedAsync() => _initTask;
+
+    /// <summary>
+    /// Persists an application state snapshot as key-value entries in the shared database.
+    /// </summary>
+    public async Task SaveAppStateAsync(AppStateSnapshot snapshot)
+    {
+        await EnsureInitializedAsync();
+        await _connection.InsertOrReplaceAsync(new KeyValueEntity { Key = "lastViewerSourceId", Value = snapshot.LastViewerSourceId ?? string.Empty });
+        await _connection.InsertOrReplaceAsync(new KeyValueEntity { Key = "streamName", Value = snapshot.StreamName ?? string.Empty });
+        await _connection.InsertOrReplaceAsync(new KeyValueEntity { Key = "isOutputActive", Value = snapshot.IsOutputActive ? "true" : "false" });
+        await _connection.InsertOrReplaceAsync(new KeyValueEntity { Key = "lastSelectedSourceId", Value = snapshot.LastSelectedSourceId ?? string.Empty });
+    }
+
+    /// <summary>
+    /// Restores an application state snapshot from key-value entries in the shared database.
+    /// </summary>
+    public async Task<AppStateSnapshot> GetAppStateAsync()
+    {
+        await EnsureInitializedAsync();
+
+        var lastViewer = await GetKeyValueAsync("lastViewerSourceId");
+        var streamName = await GetKeyValueAsync("streamName");
+        var isOutputActive = await GetKeyValueAsync("isOutputActive");
+        var lastSelected = await GetKeyValueAsync("lastSelectedSourceId");
+
+        return new AppStateSnapshot(
+            string.IsNullOrEmpty(lastViewer) ? null : lastViewer,
+            string.IsNullOrEmpty(streamName) ? null : streamName,
+            isOutputActive == "true",
+            string.IsNullOrEmpty(lastSelected) ? null : lastSelected);
+    }
+
+    private async Task<string?> GetKeyValueAsync(string key)
+    {
+        try
+        {
+            var entity = await _connection.FindAsync<KeyValueEntity>(key);
+            return entity?.Value;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private async Task EnsureAppStateColumnsAsync()
+    {
+        // The app_state table is used for key-value entries with string primary keys.
+        // CreateTableAsync is idempotent — safe to call on every init.
+        try
+        {
+            await _connection.Table<KeyValueEntity>().ToListAsync();
+        }
+        catch
+        {
+            // Table does not exist yet; InitAsync already called CreateTableAsync above.
+        }
+    }
 
     public async Task UpsertSourceAsync(NdiSource source)
     {

--- a/src/MauiApp/MauiProgram.cs
+++ b/src/MauiApp/MauiProgram.cs
@@ -59,8 +59,9 @@ public static class MauiProgram
 
         // Services
         builder.Services.AddSingleton<NdiForAndroid.Features.Home.ViewModels.HomeDashboardService>();
+        var ndiDbPath = Path.Combine(FileSystem.AppDataDirectory, "ndi.db3");
         builder.Services.AddSingleton<IAppStateRepository>(sp =>
-            new AppStateRepository(Path.Combine(FileSystem.AppDataDirectory, "app_state.db3")));
+            new AppStateRepository(ndiDbPath));
         builder.Services.AddSingleton<IConnectionHistoryService, ConnectionHistoryService>();
         builder.Services.AddSingleton<IDeepLinkService, DeepLinkService>();
         builder.Services.AddSingleton<ITelemetryService, TelemetryService>();


### PR DESCRIPTION
## Summary
Application state was persisted to a separate `app_state.db3` file, which could go missing after migration (#143). This consolidates it into the single shared `NdiDatabase` file (`ndi.db3`).

## Changes
- `MauiProgram.cs`: point `AppStateRepository` at `ndi.db3` instead of `app_state.db3`
- `NdiDatabase.cs`: add `KeyValueEntity` (`app_state` table) + `SaveAppStateAsync`/`GetAppStateAsync`, create the table in `InitAsync`, and add an internal `NdiDatabase(dbPath)` ctor for test isolation
- `AppStateRepository.cs`: doc updates + async `EnsureInitialized`

## Notes
Reworked from the original `bugfix/143` branch to include **only** the database change. That branch also bundled unrelated, now-stale edits (CI-workflow archiving that conflicts with current `main`, deletion/rewrite of agent docs) which were intentionally dropped.

Verified: solution builds, 172/172 unit tests pass.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)