### PR TITLE
feat: NDI send — screen share, camera, microphone (#278)

### DIFF
--- a/src/Core/Features/Output/Repositories/IOutputConfigurationRepository.cs
+++ b/src/Core/Features/Output/Repositories/IOutputConfigurationRepository.cs
@@ -1,0 +1,52 @@
+using NdiForAndroid.Services;
+
+namespace NdiForAndroid.Features.Output.Repositories;
+
+/// <summary>Persisted NDI output preferences (stream name, video input, microphone flag).</summary>
+public sealed record OutputConfiguration(
+    string? PreferredStreamName,
+    VideoInputKind InputKind,
+    bool CaptureMicrophone);
+
+/// <summary>
+/// Persistence for the output configuration. Backed by the shared ndi.db3
+/// database (output_configuration table) in the MAUI app implementation.
+/// </summary>
+public interface IOutputConfigurationRepository
+{
+    /// <summary>Returns the persisted configuration, or null when none was saved yet.</summary>
+    Task<OutputConfiguration?> GetAsync();
+
+    Task SaveAsync(OutputConfiguration config);
+}
+
+/// <summary>
+/// Pure string ↔ enum mapping between the stored <c>LastInputKind</c> column and
+/// <see cref="VideoInputKind"/>. Lives in Core so it is unit-testable without the
+/// Android-targeted app assembly (which hosts the SQLite wrapper).
+/// </summary>
+public static class OutputConfigurationMapping
+{
+    /// <summary>
+    /// Parses a stored input-kind value. Handles the legacy Kotlin-era value
+    /// "DeviceScreen" (maps to <see cref="VideoInputKind.Screen"/>) as well as
+    /// current enum names; anything unrecognized falls back to Screen.
+    /// </summary>
+    public static VideoInputKind ParseInputKind(string? stored)
+    {
+        if (string.IsNullOrWhiteSpace(stored))
+            return VideoInputKind.Screen;
+
+        // Legacy schema value from the ported Kotlin app ("DeviceScreen"/"DiscoveredNdi").
+        if (stored.Equals("DeviceScreen", StringComparison.OrdinalIgnoreCase))
+            return VideoInputKind.Screen;
+
+        if (Enum.TryParse<VideoInputKind>(stored, ignoreCase: true, out var parsed) && Enum.IsDefined(parsed))
+            return parsed;
+
+        return VideoInputKind.Screen;
+    }
+
+    /// <summary>Serializes an input kind to its storage string (current enum name).</summary>
+    public static string ToStorageString(VideoInputKind kind) => kind.ToString();
+}

--- a/src/Core/Features/Output/ViewModels/OutputViewModel.cs
+++ b/src/Core/Features/Output/ViewModels/OutputViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using NdiForAndroid.Features.AppState.Models;
 using NdiForAndroid.Features.AppState.Repositories;
+using NdiForAndroid.Features.Output.Repositories;
 using NdiForAndroid.NdiBridge;
 using NdiForAndroid.Services;
 
@@ -10,9 +11,10 @@ namespace NdiForAndroid.Features.Output.ViewModels;
 public partial class OutputViewModel : ObservableObject, IDisposable
 {
     private readonly INdiOutputBridge _bridge;
-    private readonly IScreenSharePlatformService _screenSharePlatformService;
     private readonly IAppStateRepository _appStateRepo;
     private readonly IAppLifecycleService _lifecycle;
+    private readonly IOutputConfigurationRepository _configRepo;
+    private readonly IMainThreadDispatcher _dispatcher;
 
     [ObservableProperty]
     private string _streamName = "NDI-Android";
@@ -23,9 +25,25 @@ public partial class OutputViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private string? _statusMessage;
 
+    /// <summary>Video input feeding the output: device screen or front/rear camera.</summary>
+    [ObservableProperty]
+    private VideoInputKind _selectedInputKind = VideoInputKind.Screen;
+
+    /// <summary>Also capture and send the device microphone audio.</summary>
+    [ObservableProperty]
+    private bool _captureMicrophone;
+
+    /// <summary>True while any connected receiver reports this sender on program tally.</summary>
+    [ObservableProperty]
+    private bool _isOnProgramTally;
+
+    /// <summary>Number of receivers currently connected to this sender.</summary>
+    [ObservableProperty]
+    private int _connectionCount;
+
     /// <summary>
     /// When true, the output will capture and re-stream a discovered NDI source
-    /// rather than broadcasting the local screen share.
+    /// rather than broadcasting the selected local capture input.
     /// </summary>
     [ObservableProperty]
     private bool _isReStreamMode;
@@ -37,19 +55,44 @@ public partial class OutputViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private string? _reStreamSourceId;
 
+    public IReadOnlyList<VideoInputKind> AvailableInputKinds { get; } = new[]
+    {
+        VideoInputKind.Screen,
+        VideoInputKind.CameraFront,
+        VideoInputKind.CameraRear,
+    };
+
     public OutputViewModel(
         INdiOutputBridge bridge,
-        IScreenSharePlatformService screenSharePlatformService,
         IAppStateRepository appStateRepo,
-        IAppLifecycleService lifecycle)
+        IAppLifecycleService lifecycle,
+        IOutputConfigurationRepository configRepo,
+        IMainThreadDispatcher dispatcher)
     {
         _bridge = bridge;
-        _screenSharePlatformService = screenSharePlatformService;
         _appStateRepo = appStateRepo;
         _lifecycle = lifecycle;
+        _configRepo = configRepo;
+        _dispatcher = dispatcher;
         StatusMessage = "Tap Start to begin broadcasting from this device.";
 
         _lifecycle.AppResumed += OnAppResumed;
+        _bridge.OutputStatusChanged += OnOutputStatusChanged;
+    }
+
+    /// <summary>Loads the persisted output configuration (called when the page appears).</summary>
+    [RelayCommand]
+    private async Task LoadAsync()
+    {
+        var config = await _configRepo.GetAsync();
+        if (config is null)
+            return;
+
+        if (!string.IsNullOrWhiteSpace(config.PreferredStreamName))
+            StreamName = config.PreferredStreamName;
+
+        SelectedInputKind = config.InputKind;
+        CaptureMicrophone = config.CaptureMicrophone;
     }
 
     private async void OnAppResumed()
@@ -62,6 +105,16 @@ public partial class OutputViewModel : ObservableObject, IDisposable
             StatusMessage = "Output session restored.";
             StreamName = state.StreamName;
         }
+    }
+
+    /// <summary>Bridge status poll changed — marshal tally/connection refresh to the UI thread.</summary>
+    private void OnOutputStatusChanged(object? sender, EventArgs e)
+    {
+        _dispatcher.BeginInvokeOnMainThread(() =>
+        {
+            IsOnProgramTally = _bridge.IsOnProgramTally;
+            ConnectionCount = _bridge.ConnectionCount;
+        });
     }
 
     [RelayCommand]
@@ -77,7 +130,7 @@ public partial class OutputViewModel : ObservableObject, IDisposable
         }
         else
         {
-            StatusMessage = "Screen-share mode: stream your screen as an NDI sender.";
+            StatusMessage = "Capture mode: stream your screen or camera as an NDI sender.";
         }
 
         // Persist mode so it survives app restarts / process death.
@@ -113,11 +166,17 @@ public partial class OutputViewModel : ObservableObject, IDisposable
             }
             else
             {
-                // Start screen-share mode (broadcast local display as NDI).
-                await _screenSharePlatformService.StartForegroundSessionAsync(StreamName, cancellationToken);
-                await _bridge.StartOutputAsync(StreamName, cancellationToken);
+                // Start capture output. The capture source owns the Android foreground
+                // session / permission flow — the VM only talks to the bridge.
+                await _bridge.StartOutputAsync(
+                    StreamName, SelectedInputKind, CaptureMicrophone, cancellationToken);
+
                 IsOutputActive = true;
                 StatusMessage = "Output active";
+
+                // Persist the configuration only after a successful start.
+                await _configRepo.SaveAsync(new OutputConfiguration(
+                    StreamName, SelectedInputKind, CaptureMicrophone));
             }
 
             // Persist output state so it survives resume / process death.
@@ -128,11 +187,16 @@ public partial class OutputViewModel : ObservableObject, IDisposable
                 true,
                 snapshot.LastSelectedSourceId));
         }
+        catch (OperationCanceledException)
+        {
+            // The user declined the capture permission (e.g. MediaProjection consent).
+            IsOutputActive = false;
+            StatusMessage = "Permission declined — output not started.";
+        }
         catch (Exception ex)
         {
             IsOutputActive = false;
             StatusMessage = $"Output failed: {ex.Message}";
-            await _screenSharePlatformService.StopForegroundSessionAsync(cancellationToken);
         }
     }
 
@@ -146,11 +210,12 @@ public partial class OutputViewModel : ObservableObject, IDisposable
         else
         {
             await _bridge.StopOutputAsync(cancellationToken);
-            await _screenSharePlatformService.StopForegroundSessionAsync(cancellationToken);
         }
 
         IsOutputActive = false;
         StatusMessage = null;
+        IsOnProgramTally = false;
+        ConnectionCount = 0;
 
         // Clear output state but keep viewer source.
         var snapshot = await _appStateRepo.RestoreStateAsync();
@@ -164,5 +229,6 @@ public partial class OutputViewModel : ObservableObject, IDisposable
     public void Dispose()
     {
         _lifecycle.AppResumed -= OnAppResumed;
+        _bridge.OutputStatusChanged -= OnOutputStatusChanged;
     }
 }

--- a/src/Core/NdiBridge/INdiBridges.cs
+++ b/src/Core/NdiBridge/INdiBridges.cs
@@ -83,11 +83,30 @@ public interface INdiOutputBridge
 {
     /// <summary>
     /// Starts an NDI sender that advertises this device on the network under
-    /// <paramref name="streamName"/>. No remote sourceId is required.
+    /// <paramref name="streamName"/>, fed by the selected capture input.
     /// </summary>
-    Task StartOutputAsync(string streamName, CancellationToken cancellationToken = default);
+    /// <param name="streamName">Advertised NDI source name (device name is prepended by the SDK).</param>
+    /// <param name="inputKind">Video input: device screen or front/rear camera.</param>
+    /// <param name="captureMicrophone">Also capture and send device microphone audio.</param>
+    Task StartOutputAsync(
+        string streamName,
+        Services.VideoInputKind inputKind = Services.VideoInputKind.Screen,
+        bool captureMicrophone = false,
+        CancellationToken cancellationToken = default);
 
     Task StopOutputAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>True while any connected receiver reports this sender on program tally.</summary>
+    bool IsOnProgramTally { get; }
+
+    /// <summary>Number of receivers currently connected to this sender (0 when idle).</summary>
+    int ConnectionCount { get; }
+
+    /// <summary>
+    /// Raised (on a background thread) when <see cref="IsOnProgramTally"/> or
+    /// <see cref="ConnectionCount"/> changed. Subscribers marshal to the UI thread.
+    /// </summary>
+    event EventHandler? OutputStatusChanged;
 
     /// <summary>
     /// Starts an NDI sender that re-streams frames captured from the specified

--- a/src/Core/Services/ICaptureSources.cs
+++ b/src/Core/Services/ICaptureSources.cs
@@ -1,0 +1,78 @@
+namespace NdiForAndroid.Services;
+
+/// <summary>Video input selected for NDI output.</summary>
+public enum VideoInputKind
+{
+    Screen,
+    CameraFront,
+    CameraRear,
+}
+
+/// <summary>Pixel format of a captured frame. All are accepted natively by NDI send (no conversion).</summary>
+public enum CapturedPixelFormat
+{
+    /// <summary>32-bit BGRA.</summary>
+    Bgra32,
+
+    /// <summary>32-bit RGBA (Android ImageReader RGBA_8888 — screen capture).</summary>
+    Rgba32,
+
+    /// <summary>NV12 (Y plane + interleaved UV — Android camera YUV_420_888 repacked).</summary>
+    Nv12,
+}
+
+/// <summary>
+/// One captured video frame. The producer owns and reuses <see cref="Data"/>:
+/// consumers must finish with the buffer before the event handler returns
+/// (the NDI bridge sends synchronously from the callback for this reason).
+/// </summary>
+public sealed record CapturedVideoFrame(
+    int Width,
+    int Height,
+    CapturedPixelFormat Format,
+    byte[] Data,
+    int StrideBytes,
+    int FrameRateN = 30,
+    int FrameRateD = 1);
+
+/// <summary>
+/// One captured audio chunk: interleaved float PCM (±1.0), producer-owned buffer,
+/// same consume-before-return rule as video.
+/// </summary>
+public sealed record CapturedAudioChunk(
+    int SampleRate,
+    int Channels,
+    float[] InterleavedSamples,
+    int FrameCount);
+
+/// <summary>
+/// Platform video capture (screen via MediaProjection, camera via Camera2).
+/// Frames are raised on a capture thread — never the UI thread.
+/// </summary>
+public interface IVideoCaptureSource
+{
+    event EventHandler<CapturedVideoFrame>? FrameReady;
+
+    bool IsActive { get; }
+
+    /// <summary>
+    /// Starts capture. For <see cref="VideoInputKind.Screen"/> this includes the
+    /// MediaProjection consent flow; the returned task faults with
+    /// <see cref="OperationCanceledException"/> if the user declines.
+    /// </summary>
+    Task StartAsync(VideoInputKind kind, CancellationToken cancellationToken = default);
+
+    Task StopAsync();
+}
+
+/// <summary>Platform microphone capture (AudioRecord float PCM on Android).</summary>
+public interface IAudioCaptureSource
+{
+    event EventHandler<CapturedAudioChunk>? ChunkReady;
+
+    bool IsActive { get; }
+
+    Task StartAsync(CancellationToken cancellationToken = default);
+
+    Task StopAsync();
+}

--- a/src/MauiApp/Converters/ValueConverters.cs
+++ b/src/MauiApp/Converters/ValueConverters.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using NdiForAndroid.Services;
 
 namespace NdiForAndroid.Converters;
 
@@ -20,4 +21,20 @@ public sealed class InverseBoolConverter : IValueConverter
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => value is bool b && !b;
+}
+
+/// <summary>Maps a <see cref="VideoInputKind"/> to a user-facing label (Picker display).</summary>
+public sealed class VideoInputKindDisplayConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value switch
+        {
+            VideoInputKind.Screen => "Screen",
+            VideoInputKind.CameraFront => "Front camera",
+            VideoInputKind.CameraRear => "Rear camera",
+            _ => value?.ToString() ?? string.Empty,
+        };
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
 }

--- a/src/MauiApp/Data/NdiDatabase.cs
+++ b/src/MauiApp/Data/NdiDatabase.cs
@@ -69,10 +69,11 @@ public sealed class OutputConfigurationEntity
 {
     [PrimaryKey] public int Id { get; set; } = 1;
     public string? PreferredStreamName { get; set; }
-    public string LastInputKind { get; set; } = "DeviceScreen";  // DeviceScreen, DiscoveredNdi
+    public string LastInputKind { get; set; } = "DeviceScreen";  // legacy: DeviceScreen, DiscoveredNdi; current: VideoInputKind names
     public string? LastSourceId { get; set; }
     public bool RetryEnabled { get; set; } = true;
     public int RetryWindowSeconds { get; set; } = 30;
+    public bool CaptureMicrophone { get; set; }  // #278: send device microphone audio (additive column — CreateTableAsync migrates)
 }
 
 [Table("output_session")]

--- a/src/MauiApp/Features/Output/Repositories/OutputConfigurationRepository.cs
+++ b/src/MauiApp/Features/Output/Repositories/OutputConfigurationRepository.cs
@@ -1,0 +1,45 @@
+using NdiForAndroid.Data;
+
+namespace NdiForAndroid.Features.Output.Repositories;
+
+/// <summary>
+/// SQLite-backed output configuration persistence — wraps the forward-declared
+/// output_configuration table in the shared ndi.db3 database (issue #240).
+/// String ↔ enum mapping is delegated to <see cref="OutputConfigurationMapping"/>
+/// in Core so it stays unit-testable without this Android-targeted assembly.
+/// </summary>
+public sealed class OutputConfigurationRepository : IOutputConfigurationRepository
+{
+    private readonly NdiDatabase _database;
+
+    public OutputConfigurationRepository(NdiDatabase database)
+    {
+        _database = database;
+    }
+
+    public async Task<OutputConfiguration?> GetAsync()
+    {
+        var entity = await _database.GetOutputConfigurationAsync();
+        if (entity is null)
+            return null;
+
+        return new OutputConfiguration(
+            entity.PreferredStreamName,
+            OutputConfigurationMapping.ParseInputKind(entity.LastInputKind),
+            entity.CaptureMicrophone);
+    }
+
+    public async Task SaveAsync(OutputConfiguration config)
+    {
+        // Preserve the untouched legacy columns (LastSourceId, retry settings)
+        // by updating the existing row when present.
+        var entity = await _database.GetOutputConfigurationAsync()
+            ?? new OutputConfigurationEntity { Id = 1 };
+
+        entity.PreferredStreamName = config.PreferredStreamName;
+        entity.LastInputKind = OutputConfigurationMapping.ToStorageString(config.InputKind);
+        entity.CaptureMicrophone = config.CaptureMicrophone;
+
+        await _database.SaveOutputConfigurationAsync(entity);
+    }
+}

--- a/src/MauiApp/Features/Output/Views/OutputPage.xaml
+++ b/src/MauiApp/Features/Output/Views/OutputPage.xaml
@@ -10,7 +10,7 @@
         <!-- Mode toggle -->
         <Frame>
             <HorizontalStackLayout Spacing="8" HorizontalOptions="Center">
-                <Label Text="Screen-share:" VerticalOptions="Center" />
+                <Label Text="Capture:" VerticalOptions="Center" />
                 <Switch IsToggled="{Binding IsReStreamMode, Converter={StaticResource InverseBoolConverter}}" />
                 <Label Text="Re-stream:" VerticalOptions="Center" />
             </HorizontalStackLayout>
@@ -22,6 +22,24 @@
                Placeholder="NDI-Android"
                IsEnabled="{Binding IsOutputActive, Converter={StaticResource InverseBoolConverter}}" />
 
+        <!-- Video input selection (capture mode only) -->
+        <Label Text="Video Input"
+               FontAttributes="Bold"
+               IsVisible="{Binding IsReStreamMode, Converter={StaticResource InverseBoolConverter}}" />
+        <Picker ItemsSource="{Binding AvailableInputKinds}"
+                SelectedItem="{Binding SelectedInputKind}"
+                ItemDisplayBinding="{Binding ., Converter={StaticResource VideoInputKindDisplayConverter}}"
+                IsVisible="{Binding IsReStreamMode, Converter={StaticResource InverseBoolConverter}}"
+                IsEnabled="{Binding IsOutputActive, Converter={StaticResource InverseBoolConverter}}" />
+
+        <!-- Microphone audio (capture mode only) -->
+        <HorizontalStackLayout Spacing="8"
+                               IsVisible="{Binding IsReStreamMode, Converter={StaticResource InverseBoolConverter}}">
+            <Switch IsToggled="{Binding CaptureMicrophone}"
+                    IsEnabled="{Binding IsOutputActive, Converter={StaticResource InverseBoolConverter}}" />
+            <Label Text="Send microphone audio" VerticalOptions="Center" />
+        </HorizontalStackLayout>
+
         <!-- Re-stream source selector (only visible in re-stream mode) -->
         <Label Text="Re-stream Source ID"
                FontAttributes="Bold"
@@ -30,6 +48,20 @@
                Placeholder="Select a source on Sources page"
                IsVisible="{Binding IsReStreamMode}"
                IsEnabled="{Binding IsOutputActive, Converter={StaticResource InverseBoolConverter}}" />
+
+        <!-- Live status: connection count + program tally -->
+        <HorizontalStackLayout Spacing="12"
+                               HorizontalOptions="Center"
+                               IsVisible="{Binding IsOutputActive}">
+            <Label Text="{Binding ConnectionCount, StringFormat='Connections: {0}'}"
+                   TextColor="{DynamicResource TextSecondary}"
+                   VerticalOptions="Center" />
+            <Label Text="ON AIR"
+                   FontAttributes="Bold"
+                   TextColor="{DynamicResource ErrorRed}"
+                   IsVisible="{Binding IsOnProgramTally}"
+                   VerticalOptions="Center" />
+        </HorizontalStackLayout>
 
         <!-- Status -->
         <Label Text="{Binding StatusMessage}" HorizontalOptions="Center" />

--- a/src/MauiApp/Features/Output/Views/OutputPage.xaml.cs
+++ b/src/MauiApp/Features/Output/Views/OutputPage.xaml.cs
@@ -13,4 +13,12 @@ public partial class OutputPage : ContentPage
         _viewModel = viewModel;
         BindingContext = viewModel;
     }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+
+        // Lifecycle wiring only (no logic): load the persisted output configuration.
+        _viewModel.LoadCommand.Execute(null);
+    }
 }

--- a/src/MauiApp/MauiProgram.cs
+++ b/src/MauiApp/MauiProgram.cs
@@ -8,6 +8,7 @@ using NdiForAndroid.Features.DeepLinking.Services;
 using NdiForAndroid.Features.Home.ViewModels;
 using NdiForAndroid.Features.Navigation.Services;
 using NdiForAndroid.Features.Navigation.ViewModels;
+using NdiForAndroid.Features.Output.Repositories;
 using NdiForAndroid.Features.Output.ViewModels;
 using NdiForAndroid.Features.Settings.Repositories;
 using NdiForAndroid.Features.Settings.Services;
@@ -55,6 +56,7 @@ public static class MauiProgram
 
         // Repositories
         builder.Services.AddSingleton<ISourceRepository, SourceRepository>();
+        builder.Services.AddSingleton<IOutputConfigurationRepository, OutputConfigurationRepository>();
         builder.Services.AddSingleton<ISettingsRepository, SettingsRepository>();
         builder.Services.AddSingleton<ISettingsValidationService, SettingsValidationService>();
         builder.Services.AddSingleton<IDiscoverySettingsOrchestrator, DiscoverySettingsOrchestrator>();
@@ -95,12 +97,16 @@ public static class MauiProgram
         builder.Services.AddSingleton<ISettingsPlatformService, AndroidSettingsPlatformService>();
         builder.Services.AddSingleton<INdiPlatformBootstrap, AndroidNsdBootstrap>();
         builder.Services.AddSingleton<IAudioPlaybackSink, AndroidAudioPlaybackSink>();
+        builder.Services.AddSingleton<IVideoCaptureSource, AndroidVideoCaptureSource>();
+        builder.Services.AddSingleton<IAudioCaptureSource, AndroidMicrophoneCaptureSource>();
 #else
         builder.Services.AddSingleton<IMulticastLockService, NoopMulticastLockService>();
         builder.Services.AddSingleton<IScreenSharePlatformService, NoopScreenSharePlatformService>();
         builder.Services.AddSingleton<ISettingsPlatformService, DefaultSettingsPlatformService>();
         builder.Services.AddSingleton<INdiPlatformBootstrap, DefaultNdiPlatformBootstrap>();
         builder.Services.AddSingleton<IAudioPlaybackSink, NoopAudioPlaybackSink>();
+        builder.Services.AddSingleton<IVideoCaptureSource, NoopVideoCaptureSource>();
+        builder.Services.AddSingleton<IAudioCaptureSource, NoopAudioCaptureSource>();
 #endif
 
         // ViewModels

--- a/src/MauiApp/NdiBridge/Interop/NdiNativeMethods.cs
+++ b/src/MauiApp/NdiBridge/Interop/NdiNativeMethods.cs
@@ -131,6 +131,43 @@ internal static partial class NdiNativeMethods
     [return: MarshalAs(UnmanagedType.I1)]
     public static extern bool NDIlib_recv_ptz_focus(IntPtr instance, float focusValue);
 
+    // ── Send ─────────────────────────────────────────────────────────────────
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr NDIlib_send_create(ref NdiSendCreateNative create);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void NDIlib_send_destroy(IntPtr instance);
+
+    /// <summary>Synchronous send — buffer is fully consumed on return.</summary>
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void NDIlib_send_send_video_v2(IntPtr instance, ref NdiVideoFrameV2Native video);
+
+    /// <summary>
+    /// Async send — the SDK owns the buffer until the NEXT async send (or flush).
+    /// Use ping-pong buffers and flush with <see cref="NDIlib_send_send_video_async_v2_flush"/>.
+    /// </summary>
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void NDIlib_send_send_video_async_v2(IntPtr instance, ref NdiVideoFrameV2Native video);
+
+    [DllImport(Lib, EntryPoint = "NDIlib_send_send_video_async_v2", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void NDIlib_send_send_video_async_v2_flush(IntPtr instance, IntPtr nullFrame);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void NDIlib_send_send_audio_v3(IntPtr instance, ref NdiAudioFrameV3Native audio);
+
+    /// <summary>Convenience: interleaved float PCM in, SDK converts to planar FLTP.</summary>
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void NDIlib_util_send_send_audio_interleaved_32f(
+        IntPtr instance, ref NdiAudioFrameInterleaved32fNative audio);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    public static extern bool NDIlib_send_get_tally(IntPtr instance, ref NdiTallyNative tally, uint timeoutMs);
+
+    [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]
+    public static extern int NDIlib_send_get_no_connections(IntPtr instance, uint timeoutMs);
+
     // ── Frame sync (pull-clocked receive on top of a recv instance) ──────────
 
     [DllImport(Lib, CallingConvention = CallingConvention.Cdecl)]

--- a/src/MauiApp/NdiBridge/Interop/NdiNativeStructs.cs
+++ b/src/MauiApp/NdiBridge/Interop/NdiNativeStructs.cs
@@ -151,3 +151,24 @@ internal struct NdiRecvPerformanceNative
     public long audio_frames;
     public long metadata_frames;
 }
+
+/// <summary>NDIlib_send_create_t.</summary>
+[StructLayout(LayoutKind.Sequential)]
+internal struct NdiSendCreateNative
+{
+    public IntPtr p_ndi_name; // advertised source name (device name is prepended by the SDK)
+    public IntPtr p_groups;   // NULL for default
+    [MarshalAs(UnmanagedType.I1)] public bool clock_video; // true: send call paces to real time
+    [MarshalAs(UnmanagedType.I1)] public bool clock_audio;
+}
+
+/// <summary>NDIlib_audio_frame_interleaved_32f_t — for NDIlib_util_send_send_audio_interleaved_32f.</summary>
+[StructLayout(LayoutKind.Sequential)]
+internal struct NdiAudioFrameInterleaved32fNative
+{
+    public int sample_rate;
+    public int no_channels;
+    public int no_samples;
+    public long timecode;   // NdiVideoFrameV2Native.TimecodeSynthesize for auto
+    public IntPtr p_data;   // interleaved float PCM
+}

--- a/src/MauiApp/NdiBridge/NdiOutputBridge.cs
+++ b/src/MauiApp/NdiBridge/NdiOutputBridge.cs
@@ -1,35 +1,324 @@
+using System.Runtime.InteropServices;
+using NdiForAndroid.NdiBridge.Interop;
+using NdiForAndroid.Services;
+
 namespace NdiForAndroid.NdiBridge;
 
 /// <summary>
 /// P/Invoke output bridge against libndi.so — advertises this device as an NDI sender.
+///
+/// Two independent sessions:
+/// 1. Capture output: platform video (screen/camera) + optional microphone audio
+///    fed into an NDI sender. Video is sent SYNCHRONOUSLY from the capture callback
+///    because the producer owns and reuses the frame buffer — an async send would let
+///    the SDK read a buffer that is being overwritten. (Async + ping-pong buffers is
+///    a later optimization, see NDIlib_send_send_video_async_v2.)
+/// 2. Re-stream: a dedicated receiver pumps frames from a remote NDI source straight
+///    into a dedicated sender (zero-copy: the recv-owned native buffer is forwarded
+///    to the synchronous send, then freed).
 /// </summary>
 public sealed class NdiOutputBridge : INdiOutputBridge, IDisposable
 {
-    private bool _disposed;
-    private string? _activeStreamName;
+    private const uint ReStreamCaptureTimeoutMs = 1000;
+    private static readonly TimeSpan StatusPollInterval = TimeSpan.FromSeconds(1);
 
-    // Re-stream resources
+    private readonly NdiRuntime _runtime;
+    private readonly IVideoCaptureSource _videoSource;
+    private readonly IAudioCaptureSource _audioSource;
+
+    /// <summary>Guards the capture-output sender handle. Held across every native send
+    /// call so StopOutputAsync can never destroy the handle mid-send.</summary>
+    private readonly object _sendLock = new();
+
+    /// <summary>Guards re-stream lifecycle state (handles + thread reference).</summary>
     private readonly object _reStreamLock = new();
-    private NdiSourceEntry? _reStreamSource;
-    private QualityProfile _reStreamQuality;
-    private bool _reStreamActive;
 
-    public bool IsReStreamActive => _reStreamActive;
+    private IntPtr _send;
+    private bool _micRequested;
+    private Timer? _statusTimer;
+    private volatile bool _isOnProgramTally;
+    private volatile int _connectionCount;
 
-    public async Task StartOutputAsync(string streamName, CancellationToken cancellationToken = default)
+    private IntPtr _reStreamRecv;
+    private IntPtr _reStreamSend;
+    private Thread? _reStreamThread;
+    private volatile bool _reStreamRunning;
+
+    private bool _disposed;
+
+    public NdiOutputBridge(NdiRuntime runtime, IVideoCaptureSource videoSource, IAudioCaptureSource audioSource)
+    {
+        _runtime = runtime;
+        _videoSource = videoSource;
+        _audioSource = audioSource;
+    }
+
+    /// <inheritdoc />
+    public event EventHandler? OutputStatusChanged;
+
+    /// <inheritdoc />
+    public bool IsOnProgramTally => _isOnProgramTally;
+
+    /// <inheritdoc />
+    public int ConnectionCount => _connectionCount;
+
+    /// <inheritdoc />
+    public bool IsReStreamActive => _reStreamRunning;
+
+    // ── Capture output ───────────────────────────────────────────────────────
+
+    public async Task StartOutputAsync(
+        string streamName,
+        VideoInputKind inputKind = VideoInputKind.Screen,
+        bool captureMicrophone = false,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(streamName))
             throw new ArgumentException("Stream name is required.", nameof(streamName));
 
-        await Task.CompletedTask; // Placeholder for NDI sender P/Invoke (NDIlib_send_create).
-        _activeStreamName = streamName;
+        // Full clean stop of any active session before starting a new one.
+        await StopOutputAsync(CancellationToken.None).ConfigureAwait(false);
+
+        if (!_runtime.EnsureInitialized())
+            throw new InvalidOperationException(
+                "The NDI runtime could not be initialized on this device (unsupported CPU or native library failure).");
+
+        lock (_sendLock)
+        {
+            var namePtr = Marshal.StringToHGlobalAnsi(streamName);
+            try
+            {
+                var create = new NdiSendCreateNative
+                {
+                    p_ndi_name = namePtr,
+                    p_groups = IntPtr.Zero,
+                    // The capture callback paces the stream — never let the SDK clock
+                    // block the capture thread to wall-clock frame times.
+                    clock_video = false,
+                    clock_audio = false,
+                };
+                _send = NdiNativeMethods.NDIlib_send_create(ref create);
+            }
+            finally
+            {
+                // The SDK copies the name string during create — safe to free now.
+                Marshal.FreeHGlobal(namePtr);
+            }
+
+            if (_send == IntPtr.Zero)
+            {
+                _runtime.ReleaseHandle();
+                throw new InvalidOperationException($"Failed to create the NDI sender '{streamName}'.");
+            }
+        }
+
+        _micRequested = captureMicrophone;
+        _videoSource.FrameReady += OnFrameReady;
+        if (captureMicrophone)
+            _audioSource.ChunkReady += OnAudioChunkReady;
+
+        try
+        {
+            // For Screen this includes the MediaProjection consent flow; the task
+            // faults with OperationCanceledException when the user declines.
+            await _videoSource.StartAsync(inputKind, cancellationToken).ConfigureAwait(false);
+
+            if (captureMicrophone)
+                await _audioSource.StartAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Permission declined or capture failure — tear the sender down and rethrow
+            // so the caller can surface the reason (OperationCanceledException = declined).
+            await StopOutputAsync(CancellationToken.None).ConfigureAwait(false);
+            throw;
+        }
+
+        _statusTimer = new Timer(PollSenderStatus, null, StatusPollInterval, StatusPollInterval);
     }
 
-    public Task StopOutputAsync(CancellationToken cancellationToken = default)
+    public async Task StopOutputAsync(CancellationToken cancellationToken = default)
     {
-        _activeStreamName = null;
-        return Task.CompletedTask;
+        // Unsubscribe first so no new frames arrive while tearing down.
+        _videoSource.FrameReady -= OnFrameReady;
+        _audioSource.ChunkReady -= OnAudioChunkReady;
+
+        var statusTimer = Interlocked.Exchange(ref _statusTimer, null);
+        statusTimer?.Dispose();
+
+        try
+        {
+            await _videoSource.StopAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            // Stop must always reach the sender teardown below.
+        }
+
+        if (_micRequested)
+        {
+            _micRequested = false;
+            try
+            {
+                await _audioSource.StopAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+                // Same: never skip native teardown.
+            }
+        }
+
+        lock (_sendLock)
+        {
+            if (_send != IntPtr.Zero)
+            {
+                NdiNativeMethods.NDIlib_send_destroy(_send);
+                _send = IntPtr.Zero;
+                _runtime.ReleaseHandle();
+            }
+        }
+
+        var statusChanged = _isOnProgramTally || _connectionCount != 0;
+        _isOnProgramTally = false;
+        _connectionCount = 0;
+        if (statusChanged)
+            RaiseOutputStatusChanged();
     }
+
+    /// <summary>
+    /// Runs on the capture thread. The producer owns <see cref="CapturedVideoFrame.Data"/>
+    /// and reuses it after this handler returns, so the frame MUST be consumed with the
+    /// synchronous send before returning.
+    /// </summary>
+    private void OnFrameReady(object? sender, CapturedVideoFrame frame)
+    {
+        try
+        {
+            if (frame.Width <= 0 || frame.Height <= 0 || frame.Data.Length == 0)
+                return;
+
+            var handle = GCHandle.Alloc(frame.Data, GCHandleType.Pinned);
+            try
+            {
+                var native = new NdiVideoFrameV2Native
+                {
+                    xres = frame.Width,
+                    yres = frame.Height,
+                    FourCC = MapFourCC(frame.Format),
+                    frame_rate_N = frame.FrameRateN,
+                    frame_rate_D = frame.FrameRateD,
+                    picture_aspect_ratio = frame.Width / (float)frame.Height,
+                    frame_format_type = (int)NdiFrameFormatType.Progressive,
+                    timecode = NdiVideoFrameV2Native.TimecodeSynthesize,
+                    p_data = handle.AddrOfPinnedObject(),
+                    line_stride_in_bytes = frame.StrideBytes,
+                    p_metadata = IntPtr.Zero,
+                };
+
+                lock (_sendLock)
+                {
+                    if (_send == IntPtr.Zero)
+                        return;
+
+                    // Synchronous by design — see class remarks (producer-owned buffer).
+                    NdiNativeMethods.NDIlib_send_send_video_v2(_send, ref native);
+                }
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+        catch
+        {
+            // A capture callback must never take down the process.
+        }
+    }
+
+    /// <summary>Runs on the audio capture thread — same consume-before-return rule as video.</summary>
+    private void OnAudioChunkReady(object? sender, CapturedAudioChunk chunk)
+    {
+        try
+        {
+            if (chunk.FrameCount <= 0 || chunk.Channels <= 0 || chunk.InterleavedSamples.Length == 0)
+                return;
+
+            var handle = GCHandle.Alloc(chunk.InterleavedSamples, GCHandleType.Pinned);
+            try
+            {
+                var native = new NdiAudioFrameInterleaved32fNative
+                {
+                    sample_rate = chunk.SampleRate,
+                    no_channels = chunk.Channels,
+                    no_samples = chunk.FrameCount,
+                    timecode = NdiVideoFrameV2Native.TimecodeSynthesize,
+                    p_data = handle.AddrOfPinnedObject(),
+                };
+
+                lock (_sendLock)
+                {
+                    if (_send == IntPtr.Zero)
+                        return;
+
+                    NdiNativeMethods.NDIlib_util_send_send_audio_interleaved_32f(_send, ref native);
+                }
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+        catch
+        {
+            // A capture callback must never take down the process.
+        }
+    }
+
+    /// <summary>1 s timer callback — polls tally + connection count while output is active.</summary>
+    private void PollSenderStatus(object? state)
+    {
+        try
+        {
+            bool onProgram;
+            int connections;
+
+            lock (_sendLock)
+            {
+                if (_send == IntPtr.Zero)
+                    return;
+
+                var tally = default(NdiTallyNative);
+                NdiNativeMethods.NDIlib_send_get_tally(_send, ref tally, 0);
+                onProgram = tally.on_program;
+                connections = NdiNativeMethods.NDIlib_send_get_no_connections(_send, 0);
+            }
+
+            var changed = onProgram != _isOnProgramTally || connections != _connectionCount;
+            _isOnProgramTally = onProgram;
+            _connectionCount = connections;
+
+            if (changed)
+                RaiseOutputStatusChanged();
+        }
+        catch
+        {
+            // Timer callbacks must never take down the process.
+        }
+    }
+
+    private void RaiseOutputStatusChanged()
+    {
+        try
+        {
+            OutputStatusChanged?.Invoke(this, EventArgs.Empty);
+        }
+        catch
+        {
+            // Subscriber failures must not break the bridge.
+        }
+    }
+
+    // ── Re-stream ────────────────────────────────────────────────────────────
 
     public async Task StartReStreamFromSourceAsync(
         string sourceId,
@@ -39,56 +328,222 @@ public sealed class NdiOutputBridge : INdiOutputBridge, IDisposable
         if (string.IsNullOrWhiteSpace(sourceId))
             throw new ArgumentException("Source id is required.", nameof(sourceId));
 
+        // Full clean stop of any previous re-stream before starting a new one.
+        await StopReStreamAsync(CancellationToken.None).ConfigureAwait(false);
+
+        if (!_runtime.EnsureInitialized())
+            throw new InvalidOperationException(
+                "The NDI runtime could not be initialized on this device (unsupported CPU or native library failure).");
+
+        // ONE runtime handle covers the recv + send pair; released in StopReStreamAsync.
         lock (_reStreamLock)
         {
-            if (_reStreamActive)
-                return; // Already active — guard against double start.
+            IntPtr recv;
+            var recvNamePtr = Marshal.StringToHGlobalAnsi("NDI for Android Re-stream");
+            var sourceIdPtr = Marshal.StringToHGlobalAnsi(sourceId);
+            try
+            {
+                // Same single-id convention as NdiViewerBridge: host:port → url address,
+                // anything else → mDNS NDI name.
+                var isUrlAddress = LooksLikeUrlAddress(sourceId);
+                var create = new NdiRecvCreateV3Native
+                {
+                    source_to_connect_to = new NdiSourceNative
+                    {
+                        p_ndi_name = isUrlAddress ? IntPtr.Zero : sourceIdPtr,
+                        p_url_address = isUrlAddress ? sourceIdPtr : IntPtr.Zero,
+                    },
+                    color_format = (int)NdiRecvColorFormat.BGRX_BGRA,
+                    bandwidth = (int)MapBandwidth(qualityProfile),
+                    allow_video_fields = false,
+                    p_ndi_recv_name = recvNamePtr,
+                };
 
-            _reStreamSource = new NdiSourceEntry(
-                sourceId,
-                $"Re-stream of {sourceId}",
-                null,
-                true,
-                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                DiscoveryMode.Mdns);
-            _reStreamQuality = qualityProfile;
-            _reStreamActive = true;
+                recv = NdiNativeMethods.NDIlib_recv_create_v3(ref create);
+                if (recv == IntPtr.Zero)
+                {
+                    _runtime.ReleaseHandle();
+                    throw new InvalidOperationException($"Failed to create the NDI receiver for '{sourceId}'.");
+                }
 
-            // Placeholder: real implementation will:
-            // 1. Create a dedicated receiver for the source via NDIlib_recv_create
-            // 2. Start reading frames in a background loop (similar to viewer bridge pattern)
-            // 3. Create an NDI sender and forward captured frames with NDIlib_send_video_v2
+                var source = create.source_to_connect_to;
+                NdiNativeMethods.NDIlib_recv_connect(recv, ref source);
+            }
+            finally
+            {
+                // The SDK copies the create/connect strings — safe to free now.
+                Marshal.FreeHGlobal(recvNamePtr);
+                Marshal.FreeHGlobal(sourceIdPtr);
+            }
+
+            IntPtr send;
+            var sendNamePtr = Marshal.StringToHGlobalAnsi($"Re-stream of {sourceId}");
+            try
+            {
+                var sendCreate = new NdiSendCreateNative
+                {
+                    p_ndi_name = sendNamePtr,
+                    p_groups = IntPtr.Zero,
+                    // The incoming stream paces us — forward frames as they arrive.
+                    clock_video = false,
+                    clock_audio = false,
+                };
+                send = NdiNativeMethods.NDIlib_send_create(ref sendCreate);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(sendNamePtr);
+            }
+
+            if (send == IntPtr.Zero)
+            {
+                NdiNativeMethods.NDIlib_recv_destroy(recv);
+                _runtime.ReleaseHandle();
+                throw new InvalidOperationException($"Failed to create the NDI re-stream sender for '{sourceId}'.");
+            }
+
+            _reStreamRecv = recv;
+            _reStreamSend = send;
+            _reStreamRunning = true;
+            _reStreamThread = new Thread(() => ReStreamPumpLoop(recv, send))
+            {
+                IsBackground = true,
+                Name = "ndi-restream-pump",
+            };
+            _reStreamThread.Start();
         }
-
-        await Task.CompletedTask;
     }
 
-    public Task StopReStreamAsync(CancellationToken cancellationToken = default)
+    public async Task StopReStreamAsync(CancellationToken cancellationToken = default)
     {
+        Thread? pumpThread;
+
         lock (_reStreamLock)
         {
-            _reStreamSource = null;
-            _reStreamActive = false;
-
-            // Placeholder: real implementation will:
-            // 1. Stop reading frames loop
-            // 2. Destroy receiver via NDIlib_recv_destroy
-            // 3. Destroy sender via NDIlib_send_destroy
+            _reStreamRunning = false;
+            pumpThread = _reStreamThread;
+            _reStreamThread = null;
         }
 
-        return Task.CompletedTask;
+        // Join OUTSIDE the lock (viewer-bridge deadlock lesson); skip self-join in
+        // case a caller ends up on the pump thread.
+        if (pumpThread is not null && !ReferenceEquals(pumpThread, Thread.CurrentThread))
+            await Task.Run(pumpThread.Join, CancellationToken.None).ConfigureAwait(false);
+
+        lock (_reStreamLock)
+        {
+            var hadHandles = _reStreamRecv != IntPtr.Zero || _reStreamSend != IntPtr.Zero;
+
+            if (_reStreamRecv != IntPtr.Zero)
+            {
+                NdiNativeMethods.NDIlib_recv_destroy(_reStreamRecv);
+                _reStreamRecv = IntPtr.Zero;
+            }
+
+            if (_reStreamSend != IntPtr.Zero)
+            {
+                NdiNativeMethods.NDIlib_send_destroy(_reStreamSend);
+                _reStreamSend = IntPtr.Zero;
+            }
+
+            // One EnsureInitialized handle was taken for the recv + send pair.
+            if (hadHandles)
+                _runtime.ReleaseHandle();
+        }
     }
+
+    /// <summary>
+    /// Dedicated pump: video-only capture from the re-stream receiver, forwarded
+    /// zero-copy into the re-stream sender. The recv-owned buffer stays valid until
+    /// NDIlib_recv_free_video_v2, which is called AFTER the synchronous send returns.
+    /// </summary>
+    private void ReStreamPumpLoop(IntPtr recv, IntPtr send)
+    {
+        try
+        {
+            while (_reStreamRunning)
+            {
+                var video = default(NdiVideoFrameV2Native);
+                var metadata = default(NdiMetadataFrameNative);
+
+                var frameType = NdiNativeMethods.NDIlib_recv_capture_v3(
+                    recv, ref video, IntPtr.Zero, ref metadata, ReStreamCaptureTimeoutMs);
+
+                switch (frameType)
+                {
+                    case NdiFrameType.Video:
+                        try
+                        {
+                            // Forward the SAME native buffer — no managed copy.
+                            NdiNativeMethods.NDIlib_send_send_video_v2(send, ref video);
+                        }
+                        finally
+                        {
+                            // Mandatory per frame — leaking = native OOM within seconds.
+                            NdiNativeMethods.NDIlib_recv_free_video_v2(recv, ref video);
+                        }
+                        break;
+
+                    case NdiFrameType.Metadata:
+                        // Not forwarded — free immediately.
+                        NdiNativeMethods.NDIlib_recv_free_metadata(recv, ref metadata);
+                        break;
+                }
+            }
+        }
+        catch
+        {
+            // A pump thread must never take down the process (unhandled exceptions
+            // on background threads are fatal in .NET).
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
 
     public void Dispose()
     {
         if (_disposed) return;
         _disposed = true;
-        _activeStreamName = null;
 
-        lock (_reStreamLock)
+        // Synchronous full teardown — safe here: no continuation depends on the caller context.
+        StopOutputAsync().GetAwaiter().GetResult();
+        StopReStreamAsync().GetAwaiter().GetResult();
+    }
+
+    private static uint MapFourCC(CapturedPixelFormat format) => format switch
+    {
+        CapturedPixelFormat.Rgba32 => NdiFourCC.RGBA,
+        CapturedPixelFormat.Bgra32 => NdiFourCC.BGRA,
+        CapturedPixelFormat.Nv12 => NdiFourCC.NV12,
+        _ => NdiFourCC.RGBA,
+    };
+
+    /// <summary>Same mapping as the viewer bridge: Smooth uses the SDK low-bandwidth stream.</summary>
+    private static NdiRecvBandwidth MapBandwidth(QualityProfile profile) => profile switch
+    {
+        QualityProfile.Smooth => NdiRecvBandwidth.Lowest,
+        _ => NdiRecvBandwidth.Highest,
+    };
+
+    /// <summary>
+    /// Heuristic shared with the viewer bridge: "host:port" (no spaces/parentheses,
+    /// numeric port suffix) is an NDI url address; anything else is an mDNS NDI name.
+    /// </summary>
+    private static bool LooksLikeUrlAddress(string sourceId)
+    {
+        if (sourceId.Contains(' ') || sourceId.Contains('('))
+            return false;
+
+        var colon = sourceId.LastIndexOf(':');
+        if (colon <= 0 || colon == sourceId.Length - 1)
+            return false;
+
+        for (var i = colon + 1; i < sourceId.Length; i++)
         {
-            _reStreamSource = null;
-            _reStreamActive = false;
+            if (!char.IsAsciiDigit(sourceId[i]))
+                return false;
         }
+
+        return true;
     }
 }

--- a/src/MauiApp/Platforms/Android/AndroidManifest.xml
+++ b/src/MauiApp/Platforms/Android/AndroidManifest.xml
@@ -10,6 +10,13 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <uses-feature android:name="android.hardware.camera.any" android:required="false" />
 
     <application android:allowBackup="true"
                  android:label="NDI for Android"

--- a/src/MauiApp/Platforms/Android/MainActivity.cs
+++ b/src/MauiApp/Platforms/Android/MainActivity.cs
@@ -6,9 +6,11 @@ using Android.Content.PM;
 using AndroidX.Core.View;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui;
+using Microsoft.Maui.ApplicationModel;
 using NdiForAndroid.Features.DeepLinking;
 using NdiForAndroid.Features.DeepLinking.Services;
 using NdiForAndroid.Features.Settings.Services;
+using NdiForAndroid.Platforms.Android.Services;
 using NdiForAndroid.Services;
 
 namespace NdiForAndroid;
@@ -52,6 +54,25 @@ public class MainActivity : MauiAppCompatActivity
         }
 
         SyncNavigationOrientation();
+
+        // API 33+: the screen-share foreground-service notification is only visible
+        // once the user grants notification permission — ask up front.
+        if (OperatingSystem.IsAndroidVersionAtLeast(33))
+            RequestPostNotificationsPermissionAsync().FireAndForget();
+    }
+
+    protected override void OnActivityResult(int requestCode, Result resultCode, Intent? data)
+    {
+        base.OnActivityResult(requestCode, resultCode, data);
+
+        // MediaProjection consent dialog result for NDI screen capture.
+        if (requestCode == AndroidVideoCaptureSource.ScreenCaptureRequestCode)
+            AndroidVideoCaptureSource.HandleScreenCaptureResult(resultCode, data);
+    }
+
+    private static async Task RequestPostNotificationsPermissionAsync()
+    {
+        await Permissions.RequestAsync<Permissions.PostNotifications>();
     }
 
     protected override void OnNewIntent(Intent? intent)

--- a/src/MauiApp/Platforms/Android/Services/AndroidMicrophoneCaptureSource.cs
+++ b/src/MauiApp/Platforms/Android/Services/AndroidMicrophoneCaptureSource.cs
@@ -1,0 +1,109 @@
+using Android.Media;
+using Microsoft.Maui.ApplicationModel;
+using NdiForAndroid.Services;
+using Encoding = Android.Media.Encoding;
+
+namespace NdiForAndroid.Platforms.Android.Services;
+
+/// <summary>
+/// Microphone capture for NDI send: 48 kHz stereo float PCM via <see cref="AudioRecord"/>,
+/// read on a dedicated thread in 4800-sample interleaved chunks (2400 frames = 50 ms).
+/// Chunks reuse a producer-owned buffer per the <see cref="IAudioCaptureSource"/>
+/// contract (consumers finish with the buffer before the event handler returns).
+/// </summary>
+public sealed class AndroidMicrophoneCaptureSource : IAudioCaptureSource
+{
+    private const int SampleRate = 48000;
+    private const int ChannelCount = 2;
+    private const int ChunkSamples = 4800; // interleaved floats per blocking read
+
+    private AudioRecord? _record;
+    private Thread? _thread;
+    private volatile bool _running;
+
+    public event EventHandler<CapturedAudioChunk>? ChunkReady;
+
+    public bool IsActive => _running;
+
+    public async Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        if (_running)
+            throw new InvalidOperationException("Microphone capture is already active; call StopAsync first.");
+
+        // MAUI requires permission requests to originate on the main thread.
+        var status = await MainThread.InvokeOnMainThreadAsync(
+            () => Permissions.RequestAsync<Permissions.Microphone>()).ConfigureAwait(false);
+        if (status != PermissionStatus.Granted)
+            throw new OperationCanceledException("Microphone permission was denied.");
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // GetMinBufferSize returns BYTES (one float sample = 4 bytes); double it for headroom.
+        var minBytes = AudioRecord.GetMinBufferSize(SampleRate, ChannelIn.Stereo, Encoding.PcmFloat);
+        if (minBytes <= 0)
+            minBytes = SampleRate * ChannelCount * sizeof(float) / 10; // ~100 ms fallback
+
+        var record = new AudioRecord(AudioSource.Mic, SampleRate, ChannelIn.Stereo, Encoding.PcmFloat, minBytes * 2);
+        if (record.State != State.Initialized)
+        {
+            record.Release();
+            throw new InvalidOperationException("AudioRecord failed to initialize (microphone busy or format unsupported).");
+        }
+
+        record.StartRecording();
+        _record = record;
+        _running = true;
+
+        var thread = new Thread(CaptureLoop) { IsBackground = true, Name = "ndi-mic-capture" };
+        _thread = thread;
+        thread.Start();
+    }
+
+    public Task StopAsync()
+    {
+        _running = false;
+
+        var record = _record;
+        // Stop the recorder first so a blocking Read in the loop unwinds promptly.
+        try { record?.Stop(); } catch { /* recorder may already be released */ }
+
+        var thread = _thread;
+        _thread = null;
+        if (thread is not null && thread.IsAlive && thread != Thread.CurrentThread)
+            thread.Join(2000);
+
+        _record = null;
+        try { record?.Release(); } catch { /* ignore — best-effort teardown */ }
+
+        return Task.CompletedTask;
+    }
+
+    private void CaptureLoop()
+    {
+        // Producer-owned reusable buffer; consumers finish before ChunkReady returns.
+        var buffer = new float[ChunkSamples];
+        while (_running)
+        {
+            try
+            {
+                var record = _record;
+                if (record is null)
+                    break;
+
+                // The final int parameter is the read mode; 0 == AudioRecord.READ_BLOCKING
+                // (the binding exposes it as a plain int, not an enum).
+                var read = record.Read(buffer, 0, buffer.Length, 0);
+                if (read < 0)
+                    break; // ERROR_* code — the recorder is unusable, exit the loop
+                if (read == 0)
+                    continue;
+
+                ChunkReady?.Invoke(this, new CapturedAudioChunk(SampleRate, ChannelCount, buffer, read / ChannelCount));
+            }
+            catch
+            {
+                // The capture loop must never crash the process; stop capturing instead.
+                break;
+            }
+        }
+    }
+}

--- a/src/MauiApp/Platforms/Android/Services/AndroidVideoCaptureSource.cs
+++ b/src/MauiApp/Platforms/Android/Services/AndroidVideoCaptureSource.cs
@@ -1,0 +1,631 @@
+using Android.App;
+using Android.Content;
+using Android.Graphics;
+using Android.Hardware.Camera2;
+using Android.Hardware.Camera2.Params;
+using Android.Hardware.Display;
+using Android.Media;
+using Android.Media.Projection;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Microsoft.Maui.ApplicationModel;
+using NdiForAndroid.Services;
+using System.Runtime.InteropServices;
+using AImage = Android.Media.Image;
+using OperationCanceledException = System.OperationCanceledException;
+
+namespace NdiForAndroid.Platforms.Android.Services;
+
+/// <summary>
+/// Android video capture for NDI send: screen via MediaProjection + ImageReader
+/// (RGBA_8888) and cameras via Camera2 + ImageReader (YUV_420_888 repacked to NV12).
+/// Frames are raised on a dedicated capture <see cref="HandlerThread"/> — never the
+/// UI thread — and reuse producer-owned buffers per the <see cref="IVideoCaptureSource"/>
+/// contract (consumers finish with the buffer before the event handler returns).
+/// </summary>
+public sealed class AndroidVideoCaptureSource : IVideoCaptureSource
+{
+    /// <summary>Activity-result request code for the MediaProjection consent dialog.</summary>
+    internal const int ScreenCaptureRequestCode = 42731;
+
+    private const int MaxScreenLongEdge = 1280; // Wi-Fi bandwidth guidance: clamp long edge
+    private const int MaxCameraWidth = 1280;
+    private const int MaxCameraHeight = 720;
+
+    /// <summary>Completed by <see cref="HandleScreenCaptureResult"/> when MainActivity receives the consent result.</summary>
+    private static TaskCompletionSource<(Result ResultCode, Intent? Data)>? _consentTcs;
+
+    private readonly IScreenSharePlatformService _screenShareService;
+    private readonly SemaphoreSlim _stopLock = new(1, 1);
+
+    private HandlerThread? _handlerThread;
+    private ImageReader? _imageReader;
+
+    // Screen capture state.
+    private MediaProjection? _projection;
+    private VirtualDisplay? _virtualDisplay;
+    private MediaProjection.Callback? _projectionCallback;
+    private bool _startedForegroundSession;
+
+    // Camera capture state.
+    private CameraDevice? _cameraDevice;
+    private CameraCaptureSession? _captureSession;
+
+    // Producer-owned reusable buffers (see class remarks).
+    private byte[]? _frameBuffer;
+    private byte[]? _chromaScratchU;
+    private byte[]? _chromaScratchV;
+
+    private volatile bool _isActive;
+
+    public AndroidVideoCaptureSource(IScreenSharePlatformService screenShareService)
+    {
+        _screenShareService = screenShareService;
+    }
+
+    public event EventHandler<CapturedVideoFrame>? FrameReady;
+
+    public bool IsActive => _isActive;
+
+    /// <summary>
+    /// Called by <c>MainActivity.OnActivityResult</c> to complete the pending
+    /// screen-capture consent flow started by <see cref="StartAsync"/>.
+    /// </summary>
+    public static void HandleScreenCaptureResult(Result resultCode, Intent? data) =>
+        _consentTcs?.TrySetResult((resultCode, data));
+
+    public async Task StartAsync(VideoInputKind kind, CancellationToken cancellationToken = default)
+    {
+        if (_isActive)
+            throw new InvalidOperationException("Video capture is already active; call StopAsync first.");
+
+        try
+        {
+            if (kind == VideoInputKind.Screen)
+                await StartScreenAsync(cancellationToken).ConfigureAwait(false);
+            else
+                await StartCameraAsync(kind, cancellationToken).ConfigureAwait(false);
+
+            _isActive = true;
+        }
+        catch
+        {
+            // Roll back any partially-created native state before surfacing the failure.
+            await StopAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public async Task StopAsync()
+    {
+        await _stopLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            _isActive = false;
+
+            // Camera teardown (no-ops for screen capture).
+            try { _captureSession?.StopRepeating(); } catch { /* session may already be closed */ }
+            try { _captureSession?.Close(); } catch { /* ignore — best-effort teardown */ }
+            _captureSession = null;
+            try { _cameraDevice?.Close(); } catch { /* ignore — best-effort teardown */ }
+            _cameraDevice = null;
+
+            // Screen teardown (no-ops for camera capture).
+            try { _virtualDisplay?.Release(); } catch { /* ignore — best-effort teardown */ }
+            _virtualDisplay = null;
+            if (_projection is { } projection)
+            {
+                try
+                {
+                    if (_projectionCallback is { } callback)
+                        projection.UnregisterCallback(callback);
+                }
+                catch { /* ignore — best-effort teardown */ }
+                try { projection.Stop(); } catch { /* ignore — best-effort teardown */ }
+            }
+            _projection = null;
+            _projectionCallback = null;
+
+            try { _imageReader?.Close(); } catch { /* ignore — best-effort teardown */ }
+            _imageReader = null;
+
+            try { _handlerThread?.QuitSafely(); } catch { /* ignore — best-effort teardown */ }
+            _handlerThread = null;
+
+            if (_startedForegroundSession)
+            {
+                _startedForegroundSession = false;
+                try
+                {
+                    await _screenShareService.StopForegroundSessionAsync().ConfigureAwait(false);
+                }
+                catch { /* foreground-service stop must never fault teardown */ }
+            }
+        }
+        finally
+        {
+            _stopLock.Release();
+        }
+    }
+
+    // ---------------------------------------------------------------- screen
+
+    private async Task StartScreenAsync(CancellationToken cancellationToken)
+    {
+        var activity = Platform.CurrentActivity
+            ?? throw new InvalidOperationException("No current activity available for the screen-capture consent dialog.");
+        var manager = (MediaProjectionManager?)activity.GetSystemService(Context.MediaProjectionService)
+            ?? throw new InvalidOperationException("MediaProjectionManager is unavailable.");
+
+        // 1. Consent FIRST (API 34 ordering: consent → FGS running → GetMediaProjection).
+        var consent = new TaskCompletionSource<(Result ResultCode, Intent? Data)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        _consentTcs = consent;
+        await MainThread.InvokeOnMainThreadAsync(() =>
+            activity.StartActivityForResult(manager.CreateScreenCaptureIntent(), ScreenCaptureRequestCode))
+            .ConfigureAwait(false);
+
+        var (resultCode, data) = await consent.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        _consentTcs = null;
+        if (resultCode != Result.Ok || data is null)
+            throw new OperationCanceledException("Screen capture consent was declined.");
+
+        // 2. The mediaProjection-typed foreground service must be RUNNING before
+        //    GetMediaProjection on API 34+.
+        await _screenShareService.StartForegroundSessionAsync("NDI-Android", cancellationToken).ConfigureAwait(false);
+        _startedForegroundSession = true;
+
+        // StartForegroundService completes asynchronously; until the service has
+        // actually reached the foreground, GetMediaProjection throws SecurityException
+        // on API 34+. Retry briefly instead of racing it.
+        MediaProjection? projection = null;
+        for (var attempt = 0; attempt < 20; attempt++)
+        {
+            try
+            {
+                projection = manager.GetMediaProjection((int)resultCode, data);
+            }
+            catch (Java.Lang.SecurityException) when (attempt < 19)
+            {
+                // Foreground service not up yet — fall through to the delay below.
+            }
+
+            if (projection is not null)
+                break;
+
+            await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (projection is null)
+            throw new InvalidOperationException("MediaProjection could not be acquired after consent.");
+
+        var handler = StartCaptureThread();
+
+        // 3. Register the projection callback BEFORE createVirtualDisplay (required on API 34+).
+        var callback = new ProjectionCallback(this);
+        projection.RegisterCallback(callback, handler);
+        _projection = projection;
+        _projectionCallback = callback;
+
+        var (width, height) = GetScreenCaptureSize();
+        var densityDpi = (int)Math.Round(Microsoft.Maui.Devices.DeviceDisplay.MainDisplayInfo.Density * 160);
+        if (densityDpi <= 0)
+            densityDpi = 160; // DisplayMetrics.DENSITY_DEFAULT
+
+        // ImageFormatType has no RGBA_8888 member; screen capture uses
+        // PixelFormat.RGBA_8888 (0x1 == Android.Graphics.Format.Rgba8888), hence the cast.
+        var reader = ImageReader.NewInstance(width, height, (ImageFormatType)Format.Rgba8888, 2 /* maxImages */);
+        reader.SetOnImageAvailableListener(new ImageListener(OnScreenImage), handler);
+        _imageReader = reader;
+
+        var surface = reader.Surface
+            ?? throw new InvalidOperationException("ImageReader surface is unavailable.");
+
+        // VirtualDisplayFlags is the semantically correct flag set; the binding's
+        // parameter type is DisplayFlags due to Mono.Android enumification, hence the cast.
+        _virtualDisplay = projection.CreateVirtualDisplay(
+            "ndi-screen", width, height, densityDpi,
+            (DisplayFlags)VirtualDisplayFlags.AutoMirror,
+            surface, null, handler);
+    }
+
+    private static (int Width, int Height) GetScreenCaptureSize()
+    {
+        var info = Microsoft.Maui.Devices.DeviceDisplay.MainDisplayInfo;
+        var width = (int)info.Width;
+        var height = (int)info.Height;
+        if (width <= 0 || height <= 0)
+            (width, height) = (1280, 720);
+
+        var longEdge = Math.Max(width, height);
+        if (longEdge > MaxScreenLongEdge)
+        {
+            var scale = (double)MaxScreenLongEdge / longEdge;
+            width = (int)Math.Round(width * scale);
+            height = (int)Math.Round(height * scale);
+        }
+
+        // Even dimensions keep NDI/encoder consumers happy.
+        return (Math.Max(2, width & ~1), Math.Max(2, height & ~1));
+    }
+
+    private void OnScreenImage(ImageReader reader)
+    {
+        AImage? image = null;
+        try
+        {
+            image = reader.AcquireLatestImage();
+            if (image is null)
+                return;
+
+            var plane = image.GetPlanes() is { Length: > 0 } planes ? planes[0] : null;
+            if (plane?.Buffer is not { } buffer)
+                return;
+
+            var width = image.Width;
+            var height = image.Height;
+            var tightStride = width * 4;
+            var required = tightStride * height;
+
+            var frame = _frameBuffer;
+            if (frame is null || frame.Length < required)
+                _frameBuffer = frame = new byte[required];
+
+            var source = JNIEnv.GetDirectBufferAddress(buffer.Handle);
+            if (source == IntPtr.Zero)
+                return; // ImageReader buffers are direct; drop the frame if not.
+
+            var rowStride = plane.RowStride;
+            if (rowStride == tightStride)
+            {
+                Marshal.Copy(source, frame, 0, required);
+            }
+            else
+            {
+                // Compact the padded rows into a tight RGBA buffer.
+                for (var row = 0; row < height; row++)
+                    Marshal.Copy(source + row * rowStride, frame, row * tightStride, tightStride);
+            }
+
+            FrameReady?.Invoke(this, new CapturedVideoFrame(
+                width, height, CapturedPixelFormat.Rgba32, frame, tightStride, 30));
+        }
+        catch
+        {
+            // Capture callbacks run on a native handler thread — never crash the process.
+        }
+        finally
+        {
+            try { image?.Close(); } catch { /* ignore — image slot is reclaimed on reader close */ }
+        }
+    }
+
+    // ---------------------------------------------------------------- camera
+
+    private async Task StartCameraAsync(VideoInputKind kind, CancellationToken cancellationToken)
+    {
+        // MAUI requires permission requests to originate on the main thread.
+        var status = await MainThread.InvokeOnMainThreadAsync(
+            () => Permissions.RequestAsync<Permissions.Camera>()).ConfigureAwait(false);
+        if (status != PermissionStatus.Granted)
+            throw new OperationCanceledException("Camera permission was denied.");
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var context = global::Android.App.Application.Context;
+        var manager = (CameraManager?)context.GetSystemService(Context.CameraService)
+            ?? throw new InvalidOperationException("CameraManager is unavailable.");
+
+        var facing = kind == VideoInputKind.CameraFront ? LensFacing.Front : LensFacing.Back;
+        var (cameraId, characteristics) = FindCamera(manager, facing);
+        var (width, height) = PickCameraSize(characteristics);
+
+        var handler = StartCaptureThread();
+
+        var reader = ImageReader.NewInstance(width, height, ImageFormatType.Yuv420888, 2 /* maxImages */);
+        reader.SetOnImageAvailableListener(new ImageListener(OnCameraImage), handler);
+        _imageReader = reader;
+        var surface = reader.Surface
+            ?? throw new InvalidOperationException("ImageReader surface is unavailable.");
+
+        var opened = new TaskCompletionSource<CameraDevice>(TaskCreationOptions.RunContinuationsAsynchronously);
+        manager.OpenCamera(cameraId, new CameraStateCallback(this, opened), handler);
+        var camera = await opened.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        _cameraDevice = camera;
+
+        var configured = new TaskCompletionSource<CameraCaptureSession>(TaskCreationOptions.RunContinuationsAsynchronously);
+        // CA1422: obsoleted on API 30 in favor of the SessionConfiguration overload, but that
+        // requires IExecutor plumbing; the deprecated overload remains functional on all our
+        // target APIs. Migration tracked in the camera follow-up issue.
+#pragma warning disable CA1422
+        camera.CreateCaptureSession(new List<Surface> { surface }, new SessionStateCallback(configured), handler);
+#pragma warning restore CA1422
+        var session = await configured.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        _captureSession = session;
+
+        var requestBuilder = camera.CreateCaptureRequest(CameraTemplate.Preview)
+            ?? throw new InvalidOperationException("Failed to create a camera capture request.");
+        requestBuilder.AddTarget(surface);
+        var request = requestBuilder.Build()
+            ?? throw new InvalidOperationException("Failed to build the camera capture request.");
+        session.SetRepeatingRequest(request, null, handler);
+    }
+
+    private static (string Id, CameraCharacteristics Characteristics) FindCamera(CameraManager manager, LensFacing facing)
+    {
+        var lensKey = CameraCharacteristics.LensFacing;
+        if (lensKey is null)
+            throw new InvalidOperationException("CameraCharacteristics.LensFacing key is unavailable.");
+
+        foreach (var id in manager.GetCameraIdList() ?? Array.Empty<string>())
+        {
+            if (manager.GetCameraCharacteristics(id) is not { } characteristics)
+                continue;
+
+            if (characteristics.Get(lensKey) is Java.Lang.Integer lens && lens.IntValue() == (int)facing)
+                return (id, characteristics);
+        }
+
+        throw new InvalidOperationException($"No {facing} camera is available on this device.");
+    }
+
+    private static (int Width, int Height) PickCameraSize(CameraCharacteristics characteristics)
+    {
+        var mapKey = CameraCharacteristics.ScalerStreamConfigurationMap;
+        var map = mapKey is null ? null : characteristics.Get(mapKey) as StreamConfigurationMap;
+        var sizes = map?.GetOutputSizes((int)ImageFormatType.Yuv420888);
+
+        // Largest YUV_420_888 size within 1280x720 (landscape); if every mode is
+        // larger, fall back to the smallest available so capture still works.
+        var best = (Width: 0, Height: 0);
+        var smallest = (Width: 0, Height: 0);
+        if (sizes is not null)
+        {
+            foreach (var size in sizes)
+            {
+                int w = size.Width, h = size.Height;
+                if (w <= 0 || h <= 0)
+                    continue;
+                if (smallest.Width == 0 || (long)w * h < (long)smallest.Width * smallest.Height)
+                    smallest = (w, h);
+                if (w <= MaxCameraWidth && h <= MaxCameraHeight && (long)w * h > (long)best.Width * best.Height)
+                    best = (w, h);
+            }
+        }
+
+        var chosen = best.Width > 0 ? best
+            : smallest.Width > 0 ? smallest
+            : (Width: MaxCameraWidth, Height: MaxCameraHeight);
+
+        // NV12 requires even dimensions.
+        return (Math.Max(2, chosen.Width & ~1), Math.Max(2, chosen.Height & ~1));
+    }
+
+    private void OnCameraImage(ImageReader reader)
+    {
+        AImage? image = null;
+        try
+        {
+            image = reader.AcquireLatestImage();
+            if (image is null)
+                return;
+
+            var planes = image.GetPlanes();
+            if (planes is not { Length: 3 })
+                return;
+
+            var width = image.Width;
+            var height = image.Height;
+            var required = width * height * 3 / 2;
+
+            var frame = _frameBuffer;
+            if (frame is null || frame.Length < required)
+                _frameBuffer = frame = new byte[required];
+
+            if (!CopyLumaPlane(planes[0], width, height, frame))
+                return;
+            if (!RepackChromaToNv12(planes[1], planes[2], width, height, frame))
+                return;
+
+            FrameReady?.Invoke(this, new CapturedVideoFrame(
+                width, height, CapturedPixelFormat.Nv12, frame, width, 30));
+        }
+        catch
+        {
+            // Capture callbacks run on a native handler thread — never crash the process.
+        }
+        finally
+        {
+            try { image?.Close(); } catch { /* ignore — image slot is reclaimed on reader close */ }
+        }
+    }
+
+    private static bool CopyLumaPlane(AImage.Plane plane, int width, int height, byte[] dst)
+    {
+        if (plane.Buffer is not { } buffer)
+            return false;
+
+        var source = JNIEnv.GetDirectBufferAddress(buffer.Handle);
+        if (source == IntPtr.Zero)
+            return false;
+
+        var rowStride = plane.RowStride;
+        if (rowStride == width)
+        {
+            Marshal.Copy(source, dst, 0, width * height);
+        }
+        else
+        {
+            for (var row = 0; row < height; row++)
+                Marshal.Copy(source + row * rowStride, dst, row * width, width);
+        }
+
+        return true;
+    }
+
+    private bool RepackChromaToNv12(AImage.Plane uPlane, AImage.Plane vPlane, int width, int height, byte[] dst)
+    {
+        if (uPlane.Buffer is not { } uBuffer || vPlane.Buffer is not { } vBuffer)
+            return false;
+
+        var uSource = JNIEnv.GetDirectBufferAddress(uBuffer.Handle);
+        var vSource = JNIEnv.GetDirectBufferAddress(vBuffer.Handle);
+        if (uSource == IntPtr.Zero || vSource == IntPtr.Zero)
+            return false;
+
+        var chromaWidth = width / 2;
+        var chromaHeight = height / 2;
+        var dstOffset = width * height;
+        var dstRowBytes = width; // chromaWidth UV byte pairs per NV12 chroma row
+
+        if (uPlane.PixelStride == 2 && vPlane.PixelStride == 2)
+        {
+            // Fast path: with PixelStride == 2 the U plane's buffer view over the
+            // underlying semi-planar allocation is already the interleaved UV (NV12)
+            // byte sequence. Copy rows directly; the view typically ends one byte
+            // before the final V sample, which is filled in from the V plane below.
+            var uRowStride = uPlane.RowStride;
+            var uAvailable = uBuffer.Remaining();
+            for (var row = 0; row < chromaHeight; row++)
+            {
+                var srcPos = row * uRowStride;
+                var count = Math.Min(dstRowBytes, uAvailable - srcPos);
+                if (count <= 0)
+                    break;
+                Marshal.Copy(uSource + srcPos, dst, dstOffset + row * dstRowBytes, count);
+            }
+
+            var lastV = (chromaHeight - 1) * vPlane.RowStride + (chromaWidth - 1) * vPlane.PixelStride;
+            dst[dstOffset + chromaHeight * dstRowBytes - 1] = Marshal.ReadByte(vSource, lastV);
+            return true;
+        }
+
+        // General fallback (fully planar or exotic strides): stage each chroma plane
+        // into a reusable scratch array with one native copy, then interleave per pixel.
+        var uLength = uBuffer.Remaining();
+        var vLength = vBuffer.Remaining();
+        var scratchU = EnsureScratch(ref _chromaScratchU, uLength);
+        var scratchV = EnsureScratch(ref _chromaScratchV, vLength);
+        Marshal.Copy(uSource, scratchU, 0, uLength);
+        Marshal.Copy(vSource, scratchV, 0, vLength);
+
+        var uPixelStride = uPlane.PixelStride;
+        var vPixelStride = vPlane.PixelStride;
+        var uRowStrideGeneral = uPlane.RowStride;
+        var vRowStrideGeneral = vPlane.RowStride;
+
+        for (var row = 0; row < chromaHeight; row++)
+        {
+            var uRow = row * uRowStrideGeneral;
+            var vRow = row * vRowStrideGeneral;
+            var dstRow = dstOffset + row * dstRowBytes;
+            for (var col = 0; col < chromaWidth; col++)
+            {
+                var uIndex = uRow + col * uPixelStride;
+                var vIndex = vRow + col * vPixelStride;
+                if (uIndex >= uLength || vIndex >= vLength)
+                    break;
+                dst[dstRow + col * 2] = scratchU[uIndex];       // NV12: U (Cb) first
+                dst[dstRow + col * 2 + 1] = scratchV[vIndex];   // then V (Cr)
+            }
+        }
+
+        return true;
+    }
+
+    private static byte[] EnsureScratch(ref byte[]? scratch, int length)
+    {
+        if (scratch is null || scratch.Length < length)
+            scratch = new byte[length];
+        return scratch;
+    }
+
+    // ---------------------------------------------------------------- shared
+
+    private Handler StartCaptureThread()
+    {
+        var thread = new HandlerThread("ndi-video-capture");
+        thread.Start();
+        var looper = thread.Looper
+            ?? throw new InvalidOperationException("Capture HandlerThread has no looper after Start().");
+        var handler = new Handler(looper);
+        _handlerThread = thread;
+        return handler;
+    }
+
+    /// <summary>Adapts ImageReader availability callbacks to an instance method.</summary>
+    private sealed class ImageListener : Java.Lang.Object, ImageReader.IOnImageAvailableListener
+    {
+        private readonly Action<ImageReader> _onImage;
+
+        public ImageListener(Action<ImageReader> onImage) => _onImage = onImage;
+
+        public void OnImageAvailable(ImageReader? reader)
+        {
+            if (reader is not null)
+                _onImage(reader);
+        }
+    }
+
+    /// <summary>
+    /// Required on API 34+ before createVirtualDisplay; stops capture cleanly when
+    /// the system (or the user, via the status bar) revokes the projection.
+    /// </summary>
+    private sealed class ProjectionCallback : MediaProjection.Callback
+    {
+        private readonly AndroidVideoCaptureSource _owner;
+
+        public ProjectionCallback(AndroidVideoCaptureSource owner) => _owner = owner;
+
+        public override void OnStop() => _owner.StopAsync().FireAndForget();
+    }
+
+    private sealed class CameraStateCallback : CameraDevice.StateCallback
+    {
+        private readonly AndroidVideoCaptureSource _owner;
+        private readonly TaskCompletionSource<CameraDevice> _opened;
+
+        public CameraStateCallback(AndroidVideoCaptureSource owner, TaskCompletionSource<CameraDevice> opened)
+        {
+            _owner = owner;
+            _opened = opened;
+        }
+
+        public override void OnOpened(CameraDevice camera) => _opened.TrySetResult(camera);
+
+        public override void OnDisconnected(CameraDevice camera) =>
+            HandleLoss(camera, new InvalidOperationException("Camera was disconnected."));
+
+        public override void OnError(CameraDevice camera, CameraError error) =>
+            HandleLoss(camera, new InvalidOperationException($"Camera reported error '{error}'."));
+
+        private void HandleLoss(CameraDevice camera, Exception error)
+        {
+            try
+            {
+                // During open: fault the awaiter. After open: stop the whole source cleanly.
+                if (!_opened.TrySetException(error))
+                    _owner.StopAsync().FireAndForget();
+                camera.Close();
+            }
+            catch
+            {
+                // Native camera callbacks must never throw into the runtime.
+            }
+        }
+    }
+
+    private sealed class SessionStateCallback : CameraCaptureSession.StateCallback
+    {
+        private readonly TaskCompletionSource<CameraCaptureSession> _configured;
+
+        public SessionStateCallback(TaskCompletionSource<CameraCaptureSession> configured) =>
+            _configured = configured;
+
+        public override void OnConfigured(CameraCaptureSession session) =>
+            _configured.TrySetResult(session);
+
+        public override void OnConfigureFailed(CameraCaptureSession session) =>
+            _configured.TrySetException(new InvalidOperationException("Camera capture session configuration failed."));
+    }
+}

--- a/src/MauiApp/Platforms/Android/Services/ScreenShareForegroundService.cs
+++ b/src/MauiApp/Platforms/Android/Services/ScreenShareForegroundService.cs
@@ -1,11 +1,15 @@
 using Android.App;
 using Android.Content;
+using Android.Content.PM;
 using Android.OS;
 using AndroidX.Core.App;
 
 namespace NdiForAndroid.Platforms.Android.Services;
 
-[Service(Exported = false, Name = "com.ndi.android.ScreenShareForegroundService", ForegroundServiceType = global::Android.Content.PM.ForegroundService.TypeMediaProjection)]
+[Service(
+    Exported = false,
+    Name = "com.ndi.android.ScreenShareForegroundService",
+    ForegroundServiceType = ForegroundService.TypeMediaProjection | ForegroundService.TypeCamera | ForegroundService.TypeMicrophone)]
 public sealed class ScreenShareForegroundService : Service
 {
     internal const string ActionStart = "com.ndi.android.action.START_SCREEN_SHARE";
@@ -27,8 +31,41 @@ public sealed class ScreenShareForegroundService : Service
         }
 
         var streamName = intent?.GetStringExtra(ExtraStreamName);
-        StartForeground(NotificationId, BuildNotification(streamName));
+        var notification = BuildNotification(streamName);
+
+        if (OperatingSystem.IsAndroidVersionAtLeast(29))
+        {
+            // API 29+: declare the active service types explicitly. Passing a type
+            // whose runtime permission is not granted throws SecurityException on
+            // API 34+, so camera/microphone are only included when currently granted.
+            StartForeground(NotificationId, notification, GetGrantedServiceTypes());
+        }
+        else
+        {
+            StartForeground(NotificationId, notification);
+        }
+
         return StartCommandResult.Sticky;
+    }
+
+    [System.Runtime.Versioning.SupportedOSPlatform("android29.0")]
+    private ForegroundService GetGrantedServiceTypes()
+    {
+        // MediaProjection is gated by the consent dialog (not a runtime permission)
+        // and the caller only starts this service after consent, so it is always safe.
+        var types = ForegroundService.TypeMediaProjection;
+
+        // Camera/microphone service types exist from API 30.
+        if (OperatingSystem.IsAndroidVersionAtLeast(30))
+        {
+            if (CheckSelfPermission(global::Android.Manifest.Permission.Camera) == Permission.Granted)
+                types |= ForegroundService.TypeCamera;
+
+            if (CheckSelfPermission(global::Android.Manifest.Permission.RecordAudio) == Permission.Granted)
+                types |= ForegroundService.TypeMicrophone;
+        }
+
+        return types;
     }
 
     private Notification BuildNotification(string? streamName)

--- a/src/MauiApp/Resources/Styles/Styles.xaml
+++ b/src/MauiApp/Resources/Styles/Styles.xaml
@@ -115,6 +115,7 @@
     <!-- Utility converters -->
     <converters:IsNotNullConverter x:Key="IsNotNullConverter" />
     <converters:InverseBoolConverter x:Key="InverseBoolConverter" />
+    <converters:VideoInputKindDisplayConverter x:Key="VideoInputKindDisplayConverter" />
 
     <!-- Static booleans -->
     <x:Boolean x:Key="True">True</x:Boolean>

--- a/src/MauiApp/Services/NoopAudioCaptureSource.cs
+++ b/src/MauiApp/Services/NoopAudioCaptureSource.cs
@@ -1,0 +1,21 @@
+namespace NdiForAndroid.Services;
+
+/// <summary>
+/// Non-Android fallback for <see cref="IAudioCaptureSource"/>: capture never
+/// starts, <see cref="IsActive"/> stays false and no chunks are raised.
+/// </summary>
+internal sealed class NoopAudioCaptureSource : IAudioCaptureSource
+{
+    // Explicit accessors: the event is intentionally never raised (avoids CS0067).
+    public event EventHandler<CapturedAudioChunk>? ChunkReady
+    {
+        add { }
+        remove { }
+    }
+
+    public bool IsActive => false;
+
+    public Task StartAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    public Task StopAsync() => Task.CompletedTask;
+}

--- a/src/MauiApp/Services/NoopVideoCaptureSource.cs
+++ b/src/MauiApp/Services/NoopVideoCaptureSource.cs
@@ -1,0 +1,21 @@
+namespace NdiForAndroid.Services;
+
+/// <summary>
+/// Non-Android fallback for <see cref="IVideoCaptureSource"/>: capture never
+/// starts, <see cref="IsActive"/> stays false and no frames are raised.
+/// </summary>
+internal sealed class NoopVideoCaptureSource : IVideoCaptureSource
+{
+    // Explicit accessors: the event is intentionally never raised (avoids CS0067).
+    public event EventHandler<CapturedVideoFrame>? FrameReady
+    {
+        add { }
+        remove { }
+    }
+
+    public bool IsActive => false;
+
+    public Task StartAsync(VideoInputKind kind, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+    public Task StopAsync() => Task.CompletedTask;
+}

--- a/tests/MauiApp.Tests/Features/Output/OutputConfigurationMappingTests.cs
+++ b/tests/MauiApp.Tests/Features/Output/OutputConfigurationMappingTests.cs
@@ -1,0 +1,54 @@
+using NdiForAndroid.Features.Output.Repositories;
+using NdiForAndroid.Services;
+using Xunit;
+
+namespace NdiForAndroid.Tests.Features.Output;
+
+/// <summary>
+/// Tests the LastInputKind string ↔ <see cref="VideoInputKind"/> mapping used by
+/// OutputConfigurationRepository. The SQLite wrapper itself lives in the
+/// net10.0-android app assembly and cannot be referenced from this test project,
+/// so the mapping logic is hosted (and tested) in Core.
+/// </summary>
+public class OutputConfigurationMappingTests
+{
+    [Theory]
+    [InlineData("Screen", VideoInputKind.Screen)]
+    [InlineData("CameraFront", VideoInputKind.CameraFront)]
+    [InlineData("CameraRear", VideoInputKind.CameraRear)]
+    [InlineData("camerarear", VideoInputKind.CameraRear)] // case-insensitive
+    public void ParseInputKind_CurrentEnumNames_ParsesExactValue(string stored, VideoInputKind expected)
+    {
+        Assert.Equal(expected, OutputConfigurationMapping.ParseInputKind(stored));
+    }
+
+    [Theory]
+    [InlineData("DeviceScreen")]  // legacy Kotlin-era value
+    [InlineData("devicescreen")]
+    public void ParseInputKind_LegacyDeviceScreen_MapsToScreen(string stored)
+    {
+        Assert.Equal(VideoInputKind.Screen, OutputConfigurationMapping.ParseInputKind(stored));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("DiscoveredNdi")] // legacy value with no capture-input equivalent
+    [InlineData("garbage")]
+    [InlineData("42")]            // numeric strings must not parse to out-of-range enum values
+    public void ParseInputKind_UnknownOrEmpty_DefaultsToScreen(string? stored)
+    {
+        Assert.Equal(VideoInputKind.Screen, OutputConfigurationMapping.ParseInputKind(stored));
+    }
+
+    [Theory]
+    [InlineData(VideoInputKind.Screen)]
+    [InlineData(VideoInputKind.CameraFront)]
+    [InlineData(VideoInputKind.CameraRear)]
+    public void ToStorageString_RoundTripsThroughParse(VideoInputKind kind)
+    {
+        var stored = OutputConfigurationMapping.ToStorageString(kind);
+        Assert.Equal(kind, OutputConfigurationMapping.ParseInputKind(stored));
+    }
+}

--- a/tests/MauiApp.Tests/Features/Output/OutputViewModelTests.cs
+++ b/tests/MauiApp.Tests/Features/Output/OutputViewModelTests.cs
@@ -1,6 +1,7 @@
 using Moq;
 using NdiForAndroid.Features.AppState.Models;
 using NdiForAndroid.Features.AppState.Repositories;
+using NdiForAndroid.Features.Output.Repositories;
 using NdiForAndroid.Features.Output.ViewModels;
 using NdiForAndroid.NdiBridge;
 using NdiForAndroid.Services;
@@ -11,22 +12,32 @@ namespace NdiForAndroid.Tests.Features.Output;
 public class OutputViewModelTests
 {
     private readonly Mock<INdiOutputBridge> _bridgeMock = new();
-    private readonly Mock<IScreenSharePlatformService> _screenShareMock = new();
     private readonly Mock<IAppStateRepository> _appStateRepoMock = new();
     private readonly Mock<IAppLifecycleService> _lifecycleMock = new();
+    private readonly Mock<IOutputConfigurationRepository> _configRepoMock = new();
+    private readonly FakeMainThreadDispatcher _dispatcher = new();
 
     public OutputViewModelTests()
     {
-        _bridgeMock.Setup(b => b.StartOutputAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _bridgeMock.Setup(b => b.StartOutputAsync(
+                It.IsAny<string>(), It.IsAny<VideoInputKind>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         _bridgeMock.Setup(b => b.StopOutputAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         _appStateRepoMock
             .Setup(r => r.RestoreStateAsync())
             .ReturnsAsync(AppStateSnapshot.Empty);
+        _configRepoMock
+            .Setup(r => r.GetAsync())
+            .ReturnsAsync((OutputConfiguration?)null);
     }
 
-    private OutputViewModel CreateSut() => new(_bridgeMock.Object, _screenShareMock.Object, _appStateRepoMock.Object, _lifecycleMock.Object);
+    private OutputViewModel CreateSut() => new(
+        _bridgeMock.Object,
+        _appStateRepoMock.Object,
+        _lifecycleMock.Object,
+        _configRepoMock.Object,
+        _dispatcher);
 
     [Fact]
     public void Constructor_SetsInitialStatusMessage()
@@ -43,17 +54,28 @@ public class OutputViewModelTests
     }
 
     [Fact]
-    public async Task StartOutputCommand_WithValidStreamName_StartsOutputAndForegroundSession()
+    public void Constructor_DefaultsToScreenInputWithoutMicrophone()
     {
-        _bridgeMock.Setup(b => b.StartOutputAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+        var sut = CreateSut();
+        Assert.Equal(VideoInputKind.Screen, sut.SelectedInputKind);
+        Assert.False(sut.CaptureMicrophone);
+        Assert.Equal(
+            new[] { VideoInputKind.Screen, VideoInputKind.CameraFront, VideoInputKind.CameraRear },
+            sut.AvailableInputKinds);
+    }
 
+    [Fact]
+    public async Task StartOutputCommand_PassesInputKindAndMicrophoneToBridge()
+    {
         var sut = CreateSut();
         sut.StreamName = "MyStream";
+        sut.SelectedInputKind = VideoInputKind.CameraRear;
+        sut.CaptureMicrophone = true;
+
         await sut.StartOutputCommand.ExecuteAsync(null);
 
-        _screenShareMock.Verify(s => s.StartForegroundSessionAsync("MyStream", It.IsAny<CancellationToken>()), Times.Once);
-        _bridgeMock.Verify(b => b.StartOutputAsync("MyStream", It.IsAny<CancellationToken>()), Times.Once);
+        _bridgeMock.Verify(b => b.StartOutputAsync(
+            "MyStream", VideoInputKind.CameraRear, true, It.IsAny<CancellationToken>()), Times.Once);
         Assert.True(sut.IsOutputActive);
         Assert.Equal("Output active", sut.StatusMessage);
     }
@@ -66,34 +88,47 @@ public class OutputViewModelTests
 
         await sut.StartOutputCommand.ExecuteAsync(null);
 
-        _screenShareMock.Verify(s => s.StartForegroundSessionAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-        _bridgeMock.Verify(b => b.StartOutputAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _bridgeMock.Verify(b => b.StartOutputAsync(
+            It.IsAny<string>(), It.IsAny<VideoInputKind>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
         Assert.False(sut.IsOutputActive);
         Assert.NotNull(sut.StatusMessage);
     }
 
     [Fact]
-    public async Task StopOutputCommand_WhenActive_StopsOutputAndForegroundSession()
+    public async Task StartOutputCommand_WhenPermissionDeclined_SetsStatusAndDoesNotMarkActive()
     {
-        _bridgeMock.Setup(b => b.StartOutputAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-        _bridgeMock.Setup(b => b.StopOutputAsync(It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+        _bridgeMock.Setup(b => b.StartOutputAsync(
+                It.IsAny<string>(), It.IsAny<VideoInputKind>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
 
         var sut = CreateSut();
         await sut.StartOutputCommand.ExecuteAsync(null);
-        await sut.StopOutputCommand.ExecuteAsync(null);
 
-        _bridgeMock.Verify(b => b.StopOutputAsync(It.IsAny<CancellationToken>()), Times.Once);
-        _screenShareMock.Verify(s => s.StopForegroundSessionAsync(It.IsAny<CancellationToken>()), Times.Once);
         Assert.False(sut.IsOutputActive);
-        Assert.Null(sut.StatusMessage);
+        Assert.Equal("Permission declined — output not started.", sut.StatusMessage);
+        _configRepoMock.Verify(r => r.SaveAsync(It.IsAny<OutputConfiguration>()), Times.Never);
     }
 
     [Fact]
-    public async Task StartOutputCommand_WhenBridgeThrows_SetsErrorStatus()
+    public async Task StartOutputCommand_PersistsConfigurationOnSuccessfulStart()
     {
-        _bridgeMock.Setup(b => b.StartOutputAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        var sut = CreateSut();
+        sut.StreamName = "MyStream";
+        sut.SelectedInputKind = VideoInputKind.CameraFront;
+        sut.CaptureMicrophone = true;
+
+        await sut.StartOutputCommand.ExecuteAsync(null);
+
+        _configRepoMock.Verify(r => r.SaveAsync(
+            new OutputConfiguration("MyStream", VideoInputKind.CameraFront, true)), Times.Once);
+    }
+
+    [Fact]
+    public async Task StartOutputCommand_WhenBridgeThrows_SetsErrorStatusAndDoesNotPersistConfig()
+    {
+        _bridgeMock.Setup(b => b.StartOutputAsync(
+                It.IsAny<string>(), It.IsAny<VideoInputKind>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("NDI send failed"));
 
         var sut = CreateSut();
@@ -101,6 +136,114 @@ public class OutputViewModelTests
 
         Assert.False(sut.IsOutputActive);
         Assert.Contains("Output failed", sut.StatusMessage);
+        _configRepoMock.Verify(r => r.SaveAsync(It.IsAny<OutputConfiguration>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StopOutputCommand_WhenActive_StopsOutputAndResetsStatus()
+    {
+        var sut = CreateSut();
+        await sut.StartOutputCommand.ExecuteAsync(null);
+        await sut.StopOutputCommand.ExecuteAsync(null);
+
+        _bridgeMock.Verify(b => b.StopOutputAsync(It.IsAny<CancellationToken>()), Times.Once);
+        Assert.False(sut.IsOutputActive);
+        Assert.Null(sut.StatusMessage);
+        Assert.False(sut.IsOnProgramTally);
+        Assert.Equal(0, sut.ConnectionCount);
+    }
+
+    [Fact]
+    public void OutputStatusChanged_UpdatesTallyAndConnectionCount()
+    {
+        _bridgeMock.SetupGet(b => b.IsOnProgramTally).Returns(true);
+        _bridgeMock.SetupGet(b => b.ConnectionCount).Returns(3);
+
+        var sut = CreateSut();
+        _bridgeMock.Raise(b => b.OutputStatusChanged += null, EventArgs.Empty);
+
+        Assert.True(sut.IsOnProgramTally);
+        Assert.Equal(3, sut.ConnectionCount);
+    }
+
+    [Fact]
+    public void Dispose_UnsubscribesFromOutputStatusChanged()
+    {
+        _bridgeMock.SetupGet(b => b.IsOnProgramTally).Returns(true);
+        _bridgeMock.SetupGet(b => b.ConnectionCount).Returns(3);
+
+        var sut = CreateSut();
+        sut.Dispose();
+        _bridgeMock.Raise(b => b.OutputStatusChanged += null, EventArgs.Empty);
+
+        Assert.False(sut.IsOnProgramTally);
+        Assert.Equal(0, sut.ConnectionCount);
+    }
+
+    [Fact]
+    public async Task LoadCommand_AppliesPersistedConfiguration()
+    {
+        _configRepoMock.Setup(r => r.GetAsync())
+            .ReturnsAsync(new OutputConfiguration("PersistedName", VideoInputKind.CameraFront, true));
+
+        var sut = CreateSut();
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        Assert.Equal("PersistedName", sut.StreamName);
+        Assert.Equal(VideoInputKind.CameraFront, sut.SelectedInputKind);
+        Assert.True(sut.CaptureMicrophone);
+    }
+
+    [Fact]
+    public async Task LoadCommand_WhenNoPersistedConfiguration_KeepsDefaults()
+    {
+        var sut = CreateSut();
+        await sut.LoadCommand.ExecuteAsync(null);
+
+        Assert.Equal("NDI-Android", sut.StreamName);
+        Assert.Equal(VideoInputKind.Screen, sut.SelectedInputKind);
+        Assert.False(sut.CaptureMicrophone);
+    }
+
+    [Fact]
+    public async Task StartOutputCommand_InReStreamMode_StartsReStreamFromSource()
+    {
+        _bridgeMock.Setup(b => b.StartReStreamFromSourceAsync(
+                It.IsAny<string>(), It.IsAny<QualityProfile>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+        sut.ReStreamSourceId = "SOURCE-1";
+        await sut.ToggleReStreamModeCommand.ExecuteAsync(null);
+        await sut.StartOutputCommand.ExecuteAsync(null);
+
+        _bridgeMock.Verify(b => b.StartReStreamFromSourceAsync(
+            "SOURCE-1", QualityProfile.Balanced, It.IsAny<CancellationToken>()), Times.Once);
+        _bridgeMock.Verify(b => b.StartOutputAsync(
+            It.IsAny<string>(), It.IsAny<VideoInputKind>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        Assert.True(sut.IsOutputActive);
+        Assert.Equal("Re-stream active", sut.StatusMessage);
+    }
+
+    [Fact]
+    public async Task StopOutputCommand_InReStreamMode_StopsReStream()
+    {
+        _bridgeMock.Setup(b => b.StartReStreamFromSourceAsync(
+                It.IsAny<string>(), It.IsAny<QualityProfile>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _bridgeMock.Setup(b => b.StopReStreamAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+        sut.ReStreamSourceId = "SOURCE-1";
+        await sut.ToggleReStreamModeCommand.ExecuteAsync(null);
+        await sut.StartOutputCommand.ExecuteAsync(null);
+        await sut.StopOutputCommand.ExecuteAsync(null);
+
+        _bridgeMock.Verify(b => b.StopReStreamAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _bridgeMock.Verify(b => b.StopOutputAsync(It.IsAny<CancellationToken>()), Times.Never);
+        Assert.False(sut.IsOutputActive);
     }
 
     [Fact]


### PR DESCRIPTION
Part of #275. The device now broadcasts as a real NDI source.

## What works
- **Screen share**: MediaProjection consent → foreground service (API-34 start ordering with SecurityException retry) → VirtualDisplay/ImageReader RGBA → NDI sync send. Long edge clamped to 1280 per NDI Wi-Fi guidance.
- **Camera**: Camera2 front/rear (≤720p YUV_420_888 → **NV12**, an NDI-native format — zero conversion), switchable via the new input-kind picker.
- **Microphone**: AudioRecord 48 kHz stereo float → NDI interleaved audio util (SDK does FLTP conversion).
- **Advertised name**: user-set, persisted (OutputConfiguration repository over the forward-declared #240 entity).
- **Sender status**: 1 s tally + connection polling → "ON AIR" indicator + connection count in the Output page.
- **Re-stream**: now a real zero-copy recv→send pump (frees the recv buffer only after the send returns).
- Foreground service declares mediaProjection|camera|microphone (permission-gated on API 30+); POST_NOTIFICATIONS requested on API 33+.

## Design notes
- Video sends are **synchronous** from the capture callback (producer-owned reusable buffers); async+ping-pong is a documented later optimization.
- `clock_video=false` — capture callbacks pace submission.

## Validation
- `dotnet build` zero warnings · `dotnet test` **206/206** (24 new)
- ⚠️ Device validation pending (no local device): consent flow, real capture, receiver-side visibility need on-device evidence before #278 closes — same gate as #277.

## Follow-up (filed separately)
Camera frames use sensor-native orientation (portrait devices produce landscape frames); CreateCaptureSession→SessionConfiguration migration.

Refs #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)