### PR TITLE
fix(ci): auto-increment version and cut a fresh release each main build

### DIFF
--- a/.github/workflows/ndi-for-android-cicd.yml
+++ b/.github/workflows/ndi-for-android-cicd.yml
@@ -216,7 +216,9 @@ jobs:
 
   # ════════════════════════════════════════════════
   # Stage 5 — Publish GitHub Release (needs emulator-tests)
-  # Ubuntu runner. Downloads the APK from stage 3 and creates a GitHub Release.
+  # Ubuntu runner. Downloads the APK from stage 3 and creates a GitHub Release
+  # tagged with the current version.properties value, then auto-increments the
+  # patch version and commits it back so the next push to main gets a fresh tag.
   # Only on main. Skipped if stage 4 was skipped.
   # ════════════════════════════════════════════════
   publish-release:
@@ -225,17 +227,41 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: github.ref == 'refs/heads/main'
+    # Serialize releases so two closely-spaced main pushes can't race on the
+    # same version/tag or clobber each other's version-bump commit.
+    concurrency:
+      group: publish-release
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Persist credentials so the auto-increment commit can be pushed back.
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read version from version.properties
         id: version
         run: |
+          set -euo pipefail
           VN=$(grep '^versionName=' version.properties | cut -d= -f2 | tr -d '[:space:]')
+          VC=$(grep '^versionCode=' version.properties | cut -d= -f2 | tr -d '[:space:]')
           if [ -z "$VN" ]; then echo "Error: versionName not found"; exit 1; fi
-          echo "VERSION_NAME=$VN" >> $GITHUB_OUTPUT
-          echo "TAG_NAME=v$VN" >> $GITHUB_OUTPUT
+          if [ -z "$VC" ]; then echo "Error: versionCode not found"; exit 1; fi
+          echo "VERSION_NAME=$VN" >> "$GITHUB_OUTPUT"
+          echo "VERSION_CODE=$VC" >> "$GITHUB_OUTPUT"
+          echo "TAG_NAME=v$VN" >> "$GITHUB_OUTPUT"
+
+      - name: Guard against existing release tag
+        # Fail loudly instead of silently overwriting a release. If this fires,
+        # version.properties was never bumped (or a previous bump commit failed).
+        run: |
+          set -euo pipefail
+          TAG="v${{ steps.version.outputs.VERSION_NAME }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists — refusing to overwrite an existing release. Bump versionName in version.properties."
+            exit 1
+          fi
+          echo "Tag ${TAG} is free — proceeding."
 
       - name: Download APK artifact
         uses: actions/download-artifact@v4
@@ -245,16 +271,39 @@ jobs:
 
       - name: Locate APK
         run: |
+          set -euo pipefail
           APK_PATH=$(find apk -name "*.apk" | head -1)
-          echo "APK_PATH=$APK_PATH" >> $GITHUB_ENV
-          echo "Publishing: $(basename $APK_PATH)"
+          echo "APK_PATH=$APK_PATH" >> "$GITHUB_ENV"
+          echo "Publishing: $(basename "$APK_PATH")"
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.version.outputs.VERSION_NAME }}
+          tag_name: ${{ steps.version.outputs.TAG_NAME }}
           name: NDI for Android ${{ steps.version.outputs.VERSION_NAME }}
           files: ${{ env.APK_PATH }}
           fail_on_unmatched_files: true
           generate_release_notes: true
           prerelease: false
+
+      - name: Bump version for next release
+        # Increment the patch version + versionCode and commit back to main so the
+        # next push publishes a new tag instead of re-hitting the one just cut.
+        # [skip ci] keeps this housekeeping commit from triggering another run.
+        run: |
+          set -euo pipefail
+          VN="${{ steps.version.outputs.VERSION_NAME }}"
+          VC="${{ steps.version.outputs.VERSION_CODE }}"
+          MAJOR=$(echo "$VN" | cut -d. -f1)
+          MINOR=$(echo "$VN" | cut -d. -f2)
+          PATCH=$(echo "$VN" | cut -d. -f3)
+          NEW_VN="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          NEW_VC=$((VC + 1))
+          sed -i "s/^versionName=.*/versionName=${NEW_VN}/" version.properties
+          sed -i "s/^versionCode=.*/versionCode=${NEW_VC}/" version.properties
+          echo "Bumped ${VN} (code ${VC}) -> ${NEW_VN} (code ${NEW_VC})"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add version.properties
+          git commit -m "chore: bump version to ${NEW_VN} (code ${NEW_VC}) [skip ci]"
+          git push origin HEAD:main

--- a/version.properties
+++ b/version.properties
@@ -1,5 +1,5 @@
 #Version incremented before build
 #Mon Jun 01 15:31:58 UTC 2026
 lastFeatureKey=033
-versionCode=394
-versionName=0.20.18
+versionCode=395
+versionName=0.20.19


### PR DESCRIPTION
The publish-release job tagged releases from a static versionName in
version.properties, which had been frozen at 0.20.18 since June 1. Every
push to main re-published to the pre-existing v0.20.18 release, silently
overwriting its APK instead of minting a new release.

- Seed version.properties to 0.20.19 (code 395).
- Guard the release step: fail loudly if the target tag already exists
  instead of overwriting an existing release.
- After publishing, auto-increment the patch version + versionCode and
  commit it back to main ([skip ci]) so the next push gets a fresh tag.
- Serialize the job via a concurrency group so concurrent main pushes
  cannot race on the same version.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PXduj2v9c9RMj5rwAZ8YyF