### PR TITLE
fix(data): use single primary keys in NdiDatabase entities

### DIFF
--- a/src/Core/Data/NdiDatabase.cs
+++ b/src/Core/Data/NdiDatabase.cs
@@ -116,29 +116,42 @@ public sealed class DiscoveryServerCheckStatusEntity
 [Table("cached_sources_discovery_server_crossref")]
 public sealed class CachedSourceCrossrefEntity
 {
-    [PrimaryKey, Column("source_id")] public string SourceId { get; set; } = string.Empty;
-    [PrimaryKey, Column("server_id")] public string ServerId { get; set; } = string.Empty;
+    // sqlite-net-pcl does not support composite primary keys (multiple [PrimaryKey]
+    // attributes make CreateTableAsync throw "more than one primary key"). Use a single
+    // surrogate key derived from (source_id, server_id) so a given pair stays unique and
+    // InsertOrReplace remains idempotent. Populated by SaveSourceServerCrossrefAsync via BuildKey.
+    [PrimaryKey, Column("id")] public string Id { get; set; } = string.Empty;
+    [Indexed, Column("source_id")] public string SourceId { get; set; } = string.Empty;
+    [Column("server_id")] public string ServerId { get; set; } = string.Empty;
     public long FirstSeenViaServerAtEpochMillis { get; set; }
+
+    public static string BuildKey(string sourceId, string serverId) => $"{sourceId}|{serverId}";
 }
 
-public sealed class NdiDatabase
+public sealed class NdiDatabase : IDisposable
 {
     private readonly SQLiteAsyncConnection _connection;
     private readonly Task _initTask;
 
-    public NdiDatabase()
-        : this(Path.Combine(FileSystem.AppDataDirectory, "ndi.db3"))
-    {
-    }
-
     /// <summary>
-    /// Creates an NdiDatabase instance pointing to a specific file path.
-    /// Internal constructor used by tests for isolation.
+    /// Creates an NdiDatabase pointing to a specific database file path.
+    /// The caller supplies the path (e.g. FileSystem.AppDataDirectory/ndi.db3 from the MAUI
+    /// composition root) so this type stays MAUI-free and unit-testable against a temp file.
     /// </summary>
-    internal NdiDatabase(string dbPath)
+    public NdiDatabase(string dbPath)
     {
         _connection = new SQLiteAsyncConnection(dbPath);
         _initTask = InitAsync();
+    }
+
+    /// <summary>
+    /// Closes the underlying SQLite connection, releasing the database file handle.
+    /// Mirrors AppStateRepository so the shared ndi.db3 file can be released (matters for
+    /// tests that delete a temp file; harmless for the app-lifetime DI singleton).
+    /// </summary>
+    public void Dispose()
+    {
+        try { _connection.CloseAsync().GetAwaiter().GetResult(); } catch { }
     }
 
     public async Task InitAsync()
@@ -457,13 +470,15 @@ public sealed class NdiDatabase
     public async Task SaveSourceServerCrossrefAsync(CachedSourceCrossrefEntity crossref)
     {
         await EnsureInitializedAsync();
+        crossref.Id = CachedSourceCrossrefEntity.BuildKey(crossref.SourceId, crossref.ServerId);
         await _connection.InsertOrReplaceAsync(crossref);
     }
 
     public async Task DeleteSourceServerCrossrefAsync(string sourceId, string serverId)
     {
         await EnsureInitializedAsync();
-        await _connection.DeleteAsync<CachedSourceCrossrefEntity>(new { sourceId, serverId });
+        await _connection.DeleteAsync<CachedSourceCrossrefEntity>(
+            CachedSourceCrossrefEntity.BuildKey(sourceId, serverId));
     }
 
     public async Task<IReadOnlyList<CachedSourceCrossrefEntity>> GetSourceServerCrossrefsAsync(string sourceId)
@@ -549,7 +564,9 @@ public sealed class NdiDatabase
 
     /// <summary>
     /// Simple entity for tracking NDI source connection events.
-    /// Uses SourceId + ConnectedAtEpochMillis as a composite key via [PrimaryKey].
+    /// Each event is a distinct row keyed by an auto-incrementing surrogate Id
+    /// (sqlite-net-pcl does not support composite primary keys). SourceId is a
+    /// plain indexed column used for per-source history queries.
     /// </summary>
     [Table("connection_history")]
     public class ConnectionHistoryEntity
@@ -557,7 +574,7 @@ public sealed class NdiDatabase
         [PrimaryKey, AutoIncrement]
         public int Id { get; set; }
 
-        [PrimaryKey]
+        [Indexed]
         public string SourceId { get; set; } = string.Empty;
 
         public string DisplayName { get; set; } = string.Empty;

--- a/src/MauiApp/Features/ConnectionHistory/ConnectionHistoryService.cs
+++ b/src/MauiApp/Features/ConnectionHistory/ConnectionHistoryService.cs
@@ -36,7 +36,11 @@ public sealed class ConnectionHistoryService : IConnectionHistoryService
             DurationSeconds = 0,
         };
 
-        await _db.InsertOrReplaceAsync(entry);
+        // Insert (not InsertOrReplace): each connect is a distinct history row.
+        // AutoIncrement Id is 0 here; InsertAsync omits it so SQLite assigns a fresh
+        // rowid and writes it back onto entry.Id for the later UpdateAsync in
+        // RecordDisconnectedAsync. InsertOrReplace would instead pin every row to Id=0.
+        await _db.InsertAsync(entry);
         _activeEntry = entry;
     }
 

--- a/src/MauiApp/MauiProgram.cs
+++ b/src/MauiApp/MauiProgram.cs
@@ -45,8 +45,10 @@ public static class MauiProgram
         builder.Logging.AddDebug();
 #endif
 
-        // Data
-        builder.Services.AddSingleton<NdiDatabase>();
+        // Data — NdiDatabase lives in Core (MAUI-free); the composition root supplies the
+        // Android app-data path so the same ndi.db3 file backs both it and AppStateRepository.
+        var ndiDbPath = Path.Combine(FileSystem.AppDataDirectory, "ndi.db3");
+        builder.Services.AddSingleton<NdiDatabase>(sp => new NdiDatabase(ndiDbPath));
 
         // NDI Bridge
         builder.Services.AddSingleton<NdiRuntime>();
@@ -64,7 +66,6 @@ public static class MauiProgram
         builder.Services.AddSingleton<IAppearanceService, MauiAppearanceService>();
 
         // Services
-        var ndiDbPath = Path.Combine(FileSystem.AppDataDirectory, "ndi.db3");
         builder.Services.AddSingleton<IAppStateRepository>(sp =>
             new AppStateRepository(ndiDbPath));
         builder.Services.AddSingleton<IConnectionHistoryService, ConnectionHistoryService>();

--- a/tests/MauiApp.Tests/Data/NdiDatabaseSchemaTests.cs
+++ b/tests/MauiApp.Tests/Data/NdiDatabaseSchemaTests.cs
@@ -1,0 +1,103 @@
+using NdiForAndroid.Data;
+using NdiForAndroid.Features.Settings.Models;
+using Xunit;
+
+namespace NdiForAndroid.Tests.Data;
+
+/// <summary>
+/// Schema-level guards for <see cref="NdiDatabase"/>. These would have caught the
+/// "table ... has more than one primary key" crash: sqlite-net-pcl rejects composite
+/// primary keys declared via multiple [PrimaryKey] attributes, so InitAsync's
+/// CreateTableAsync calls throw at startup / first write.
+/// </summary>
+public class NdiDatabaseSchemaTests
+{
+    private static string TempDbPath() =>
+        Path.Combine(Path.GetTempPath(), $"test-ndi-db-{Guid.NewGuid()}.db3");
+
+    [Fact]
+    public async Task InitAsync_CreatesEveryTable_WithoutThrowing()
+    {
+        var dbPath = TempDbPath();
+        NdiDatabase? db = null;
+        try
+        {
+            db = new NdiDatabase(dbPath);
+
+            // Faults if any entity declares a composite primary key (multiple [PrimaryKey]).
+            await db.InitAsync();
+        }
+        finally
+        {
+            db?.Dispose();
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task SaveSettingsAsync_PersistsDiscoveryServer_WithoutThrowing()
+    {
+        var dbPath = TempDbPath();
+        NdiDatabase? db = null;
+        try
+        {
+            db = new NdiDatabase(dbPath);
+            var settings = NdiSettingsSnapshot.CreateDefault() with
+            {
+                DiscoveryHost = "192.168.1.50",
+                DiscoveryPort = 5959,
+                UpdatedAtEpochMillis = 1234,
+            };
+
+            // Exact path that crashed the app: Settings → Apply → SaveSettingsAsync.
+            await db.SaveSettingsAsync(settings);
+
+            var restored = await db.GetSettingsAsync();
+            Assert.Equal("192.168.1.50", restored.DiscoveryHost);
+            Assert.Equal(5959, restored.DiscoveryPort);
+        }
+        finally
+        {
+            db?.Dispose();
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task SaveSourceServerCrossref_SamePairIsIdempotent_DifferentServerAddsRow()
+    {
+        var dbPath = TempDbPath();
+        NdiDatabase? db = null;
+        try
+        {
+            db = new NdiDatabase(dbPath);
+
+            await db.SaveSourceServerCrossrefAsync(new CachedSourceCrossrefEntity
+            {
+                SourceId = "src-1", ServerId = "srv-A", FirstSeenViaServerAtEpochMillis = 1,
+            });
+            // Same (source, server) pair: the surrogate key collapses to one row (replace, not duplicate).
+            await db.SaveSourceServerCrossrefAsync(new CachedSourceCrossrefEntity
+            {
+                SourceId = "src-1", ServerId = "srv-A", FirstSeenViaServerAtEpochMillis = 2,
+            });
+            await db.SaveSourceServerCrossrefAsync(new CachedSourceCrossrefEntity
+            {
+                SourceId = "src-1", ServerId = "srv-B", FirstSeenViaServerAtEpochMillis = 3,
+            });
+
+            var afterInserts = await db.GetSourceServerCrossrefsAsync("src-1");
+            Assert.Equal(2, afterInserts.Count);
+            Assert.Equal(2, afterInserts.Single(c => c.ServerId == "srv-A").FirstSeenViaServerAtEpochMillis);
+
+            await db.DeleteSourceServerCrossrefAsync("src-1", "srv-A");
+            var afterDelete = await db.GetSourceServerCrossrefsAsync("src-1");
+            Assert.Equal("srv-B", Assert.Single(afterDelete).ServerId);
+        }
+        finally
+        {
+            db?.Dispose();
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The app crashed with an unhandled `SQLiteException` on any database write (e.g. **Settings → Discovery → Apply**):

```
[SQLite.SQLiteException]: table "cached_sources_discovery_server_crossref" has more than one primary key
```

**Root cause:** sqlite-net-pcl does not support composite primary keys declared via multiple `[PrimaryKey]` attributes. `NdiDatabase.InitAsync` → `CreateTableAsync` threw for two entities. Read methods swallow the fault and fall back to defaults, so it went unnoticed; `SaveSettingsAsync` has no catch, so the fault propagated and killed the process. Platform-independent — it would crash real arm64 devices too.

## Fix

- **`CachedSourceCrossrefEntity`** — replaced the `source_id` + `server_id` composite PK with a single surrogate key `"{source_id}|{server_id}"` (via `BuildKey`), keeping the pair unique and `InsertOrReplace` idempotent. `source_id`/`server_id` are now plain columns (`source_id` indexed). Updated the crossref CRUD accordingly.
- **`ConnectionHistoryEntity`** — kept only `[PrimaryKey, AutoIncrement] Id`; `SourceId` is now a plain `[Indexed]` column (and corrected the stale "composite key" comment).
- **`ConnectionHistoryService.RecordConnectedAsync`** — switched `InsertOrReplaceAsync` → `InsertAsync`. This path never ran before (the table was never created); with `INSERT OR REPLACE` every event would have pinned to `Id=0` and overwritten itself, so history could never accumulate.

## Refactor (makes it unit-testable)

- Moved `NdiDatabase` from the Android-only `MauiApp` project into **Core** (`net10.0`, MAUI-free). Dropped the `FileSystem`-based parameterless constructor; the MAUI composition root now injects the `ndi.db3` path (same file used by `AppStateRepository`). Added `IDisposable`.

## Tests

- New `NdiDatabaseSchemaTests`: `InitAsync` creates every table without throwing (the direct regression guard), the Settings→Apply save path round-trips, and crossref saves are idempotent per pair.
- Full suite green: **235 passed**.

## Emulator verification

Built + installed the signed Debug APK, drove **Settings → Discovery → Apply**:
- App stayed alive (PID unchanged), crash buffer clean, no SQLite errors in logcat.
- Pulled the on-device `ndi.db3`: all 11 tables created; both fixed tables now have exactly one PK — `connection_history."Id" integer primary key autoincrement` and `cached_sources_discovery_server_crossref."id" varchar primary key` (with an index on `source_id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
