### PR TITLE
fix(di): register SQLiteAsyncConnection so viewing an NDI source doesn't crash

### DIFF
--- a/src/Core/Data/NdiDatabase.cs
+++ b/src/Core/Data/NdiDatabase.cs
@@ -145,6 +145,14 @@ public sealed class NdiDatabase : IDisposable
     }
 
     /// <summary>
+    /// The single underlying async connection. Exposed so connection-history features
+    /// (e.g. <c>ConnectionHistoryService</c>) can share this one connection rather than
+    /// opening a second handle to the same file. The <c>connection_history</c> table is
+    /// created by <see cref="InitAsync"/>, which runs at construction.
+    /// </summary>
+    public SQLiteAsyncConnection Connection => _connection;
+
+    /// <summary>
     /// Closes the underlying SQLite connection, releasing the database file handle.
     /// Mirrors AppStateRepository so the shared ndi.db3 file can be released (matters for
     /// tests that delete a temp file; harmless for the app-lifetime DI singleton).

--- a/src/MauiApp/MauiProgram.cs
+++ b/src/MauiApp/MauiProgram.cs
@@ -49,6 +49,10 @@ public static class MauiProgram
         // Android app-data path so the same ndi.db3 file backs both it and AppStateRepository.
         var ndiDbPath = Path.Combine(FileSystem.AppDataDirectory, "ndi.db3");
         builder.Services.AddSingleton<NdiDatabase>(sp => new NdiDatabase(ndiDbPath));
+        // ConnectionHistoryService depends on the raw SQLiteAsyncConnection — share the one
+        // NdiDatabase owns (so the connection_history table it creates in InitAsync is present)
+        // rather than opening a second handle to the same file.
+        builder.Services.AddSingleton<SQLite.SQLiteAsyncConnection>(sp => sp.GetRequiredService<NdiDatabase>().Connection);
 
         // NDI Bridge
         builder.Services.AddSingleton<NdiRuntime>();


### PR DESCRIPTION
## Problem
Tapping **Watch** (or **Output**) on a discovered NDI source in the View tab crashed the app:

```
System.InvalidOperationException: Unable to resolve service for type 'SQLite.SQLiteAsyncConnection'
while attempting to activate 'NdiForAndroid.Features.ConnectionHistory.ConnectionHistoryService'
  at SourceListViewModel.NavigateToViewerAsync
```

`ConnectionHistoryService` takes a raw `SQLite.SQLiteAsyncConnection` constructor parameter, but nothing registered that type in the DI container — a regression from the recent `NdiDatabase`→Core refactor. Because the service is only instantiated on the viewer-navigation path, the app ran fine until a user actually tried to view a source, which made NDI source viewing unusable.

## Fix
Expose the single `SQLiteAsyncConnection` that `NdiDatabase` already owns and register it, so `ConnectionHistoryService` shares that one connection (and the `connection_history` table created by `NdiDatabase.InitAsync` is present) rather than opening a second handle to the same file.

- `src/Core/Data/NdiDatabase.cs` — add `public SQLiteAsyncConnection Connection`
- `src/MauiApp/MauiProgram.cs` — `AddSingleton<SQLiteAsyncConnection>(sp => sp.GetRequiredService<NdiDatabase>().Connection)`

## Verification
Reproduced the crash on a physical arm64 device, applied the fix, rebuilt, and confirmed **tapping Watch now renders live video** (NDI Test Patterns source) with no crash and clean stop/teardown.

## Out of scope (separate issue)
While validating this, I also found that **NDI Discovery Server mode does not work on Android** — the app writes the correct `ndi-config.v1.json` but the native `libndi.so` never reads `NDI_CONFIG_DIR` (managed `Environment.SetEnvironmentVariable` doesn't reach native `getenv`, and native `setenv` P/Invoke won't load on MonoVM), so it falls back to mDNS and never connects to the discovery server. That needs a deeper native-load-order fix and is **not** included here. Sources can still be viewed today by adding the source host IP directly in Settings → Discovery (uses `p_extra_ips`).

## Follow-up
A DI-container resolution smoke test (resolve `ViewerViewModel` / `IConnectionHistoryService`) would guard this from regressing; the composition root lives in the `net10.0-android` head, so it isn't trivially reachable from the current `net10.0` test project — leaving as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)