### PR TITLE
fix(ndi): make Discovery Server mode work on Android

### DIFF
--- a/src/Core/Services/DiscoveryRefreshService.cs
+++ b/src/Core/Services/DiscoveryRefreshService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using NdiForAndroid.Features.Settings.Repositories;
 using NdiForAndroid.Features.Sources.Models;
 using NdiForAndroid.Features.Sources.Repositories;
 
@@ -14,6 +15,7 @@ public sealed class DiscoveryRefreshService : IDiscoveryRefreshService
     private static readonly TimeSpan DefaultDebounceWindow  = TimeSpan.FromSeconds(1);
 
     private readonly ISourceRepository _repository;
+    private readonly ISettingsRepository _settingsRepository;
     private readonly ILogger<DiscoveryRefreshService> _logger;
     private readonly TimeProvider _timeProvider;
     private readonly TimeSpan _pollingInterval;
@@ -23,6 +25,8 @@ public sealed class DiscoveryRefreshService : IDiscoveryRefreshService
     private int _isRunning;
     // 0 = idle, 1 = in-flight
     private int _isInFlight;
+    // 0 = discovery settings not yet applied this process, 1 = applied
+    private int _settingsApplied;
 
     private CancellationTokenSource? _cts;
     private DateTimeOffset _lastCompletedAt = DateTimeOffset.MinValue;
@@ -31,6 +35,7 @@ public sealed class DiscoveryRefreshService : IDiscoveryRefreshService
 
     public DiscoveryRefreshService(
         ISourceRepository repository,
+        ISettingsRepository settingsRepository,
         IAppLifecycleService lifecycle,
         ILogger<DiscoveryRefreshService> logger,
         TimeProvider? timeProvider = null,
@@ -38,6 +43,7 @@ public sealed class DiscoveryRefreshService : IDiscoveryRefreshService
         TimeSpan? debounceWindow = null)
     {
         _repository      = repository;
+        _settingsRepository = settingsRepository;
         _logger          = logger;
         _timeProvider    = timeProvider ?? TimeProvider.System;
         _pollingInterval = pollingInterval ?? DefaultPollingInterval;
@@ -82,6 +88,30 @@ public sealed class DiscoveryRefreshService : IDiscoveryRefreshService
         _ = Task.Run(() => ExecuteSinglePollAsync(CancellationToken.None));
     }
 
+    /// <summary>
+    /// Applies the persisted discovery settings (mDNS vs Discovery Server) to the NDI runtime
+    /// exactly once per process, before the first discovery poll. Without this the runtime is
+    /// only ever configured when the Settings page happens to load, so a configured discovery
+    /// server is ignored on a normal launch and discovery silently falls back to mDNS.
+    /// GetSettingsAsync applies the discovery orchestrator (and appearance) as a side effect.
+    /// </summary>
+    private async Task EnsureDiscoverySettingsAppliedAsync()
+    {
+        if (Interlocked.CompareExchange(ref _settingsApplied, 1, 0) != 0)
+            return;
+
+        try
+        {
+            await _settingsRepository.GetSettingsAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Non-fatal: discovery proceeds with whatever mode the runtime already has.
+            _logger.LogWarning(ex, "Applying persisted discovery settings before first poll failed");
+            Interlocked.Exchange(ref _settingsApplied, 0); // allow a later retry
+        }
+    }
+
     private async Task PollLoopAsync(CancellationToken ct)
     {
         while (!ct.IsCancellationRequested)
@@ -107,6 +137,7 @@ public sealed class DiscoveryRefreshService : IDiscoveryRefreshService
 
         try
         {
+            await EnsureDiscoverySettingsAppliedAsync().ConfigureAwait(false);
             var snapshot = await _repository.DiscoverAsync(ct).ConfigureAwait(false);
             _lastCompletedAt = _timeProvider.GetUtcNow();
 

--- a/src/MauiApp/NdiBridge/NdiDiscoveryBridge.cs
+++ b/src/MauiApp/NdiBridge/NdiDiscoveryBridge.cs
@@ -100,28 +100,19 @@ public sealed class NdiDiscoveryBridge : INdiDiscoveryBridge, IDisposable
         if (!_runtime.EnsureInitialized())
             return false; // Unsupported CPU / init failure — degrade to empty results.
 
-        // p_extra_ips takes hosts only (no ports), comma-separated.
-        var extraIps = _activeMode == DiscoveryMode.DiscoveryServer && _serverEndpoints.Count > 0
-            ? string.Join(',', _serverEndpoints.Select(e => e.Host).Distinct(StringComparer.OrdinalIgnoreCase))
-            : null;
-
-        var extraIpsPtr = extraIps is null ? IntPtr.Zero : Marshal.StringToHGlobalAnsi(extraIps);
-        try
+        // Discovery servers are configured via ndi-config.v1.json (networks.discovery) that
+        // NdiRuntime.SetDiscoveryServers writes and libndi reads at init — NOT via p_extra_ips.
+        // p_extra_ips is for direct NDI *source-host* IPs (machines running senders); pointing
+        // it at a discovery-server IP would just probe that host for senders (finding none) and
+        // can mask a broken discovery-server config. The app's list is discovery servers, so
+        // leave p_extra_ips empty.
+        var create = new NdiFindCreateNative
         {
-            var create = new NdiFindCreateNative
-            {
-                show_local_sources = true,
-                p_groups = IntPtr.Zero,
-                p_extra_ips = extraIpsPtr,
-            };
-            _finder = NdiNativeMethods.NDIlib_find_create_v2(ref create);
-        }
-        finally
-        {
-            // The SDK copies the create strings during find_create — safe to free now.
-            if (extraIpsPtr != IntPtr.Zero)
-                Marshal.FreeHGlobal(extraIpsPtr);
-        }
+            show_local_sources = true,
+            p_groups = IntPtr.Zero,
+            p_extra_ips = IntPtr.Zero,
+        };
+        _finder = NdiNativeMethods.NDIlib_find_create_v2(ref create);
 
         if (_finder == IntPtr.Zero)
         {

--- a/src/MauiApp/NdiBridge/NdiRuntime.cs
+++ b/src/MauiApp/NdiBridge/NdiRuntime.cs
@@ -140,11 +140,38 @@ public sealed class NdiRuntime
             });
 
             File.WriteAllText(configPath, json);
-            Environment.SetEnvironmentVariable("NDI_CONFIG_DIR", configDir);
+            SetNdiConfigDir(configDir);
         }
         catch
         {
             // Non-fatal: without config the library falls back to pure mDNS discovery.
+        }
+    }
+
+    /// <summary>
+    /// Points libndi.so at <paramref name="configDir"/> so it reads our ndi-config.v1.json
+    /// (with the discovery-server list) at <c>NDIlib_initialize</c>.
+    /// <para>
+    /// Managed <see cref="Environment.SetEnvironmentVariable(string, string?)"/> only updates the
+    /// CLR's environment cache; the native <c>getenv("NDI_CONFIG_DIR")</c> that libndi calls does
+    /// not observe it (and a libc <c>setenv</c> P/Invoke does not resolve on the Android
+    /// MonoVM). Android's <c>Os.setenv</c> is a JNI call that mutates this process's real
+    /// (native) environment, so libndi sees it. Without this the discovery-server config is
+    /// silently ignored and the library falls back to mDNS-only discovery.
+    /// </para>
+    /// </summary>
+    internal static void SetNdiConfigDir(string configDir)
+    {
+        Environment.SetEnvironmentVariable("NDI_CONFIG_DIR", configDir);
+        try
+        {
+            Android.Systems.Os.Setenv("NDI_CONFIG_DIR", configDir, true);
+        }
+        catch (Exception ex)
+        {
+            // If the native setenv is unavailable, only the managed variable is set (which
+            // libndi does not read) and discovery falls back to mDNS. Surface it for diagnosis.
+            Android.Util.Log.Warn("NDI", "Native Os.Setenv NDI_CONFIG_DIR failed: " + ex);
         }
     }
 }

--- a/src/MauiApp/Platforms/Android/MainActivity.cs
+++ b/src/MauiApp/Platforms/Android/MainActivity.cs
@@ -34,6 +34,13 @@ public class MainActivity : MauiAppCompatActivity
     {
         base.OnCreate(savedInstanceState);
 
+        // Point libndi.so at our writable config directory before any NDI P/Invoke can load
+        // the native library. NdiRuntime writes ndi-config.v1.json (with the discovery-server
+        // list) here before NDIlib_initialize; doing the env-set this early guards against the
+        // library reading NDI_CONFIG_DIR at load time. Uses the native Os.setenv (managed
+        // SetEnvironmentVariable does not reach libndi's getenv). See NdiRuntime.SetNdiConfigDir.
+        NdiForAndroid.NdiBridge.NdiRuntime.SetNdiConfigDir(FileSystem.AppDataDirectory);
+
         // Check if launched from a deep link on startup
         var launchIntent = Intent?.Data;
         if (launchIntent != null

--- a/tests/MauiApp.Tests/Services/DiscoveryRefreshServiceTests.cs
+++ b/tests/MauiApp.Tests/Services/DiscoveryRefreshServiceTests.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using NdiForAndroid.Features.Settings.Models;
+using NdiForAndroid.Features.Settings.Repositories;
 using NdiForAndroid.Features.Sources.Models;
 using NdiForAndroid.Features.Sources.Repositories;
 using NdiForAndroid.Services;
@@ -10,6 +12,7 @@ namespace NdiForAndroid.Tests.Services;
 public class DiscoveryRefreshServiceTests
 {
     private readonly Mock<ISourceRepository> _repositoryMock = new();
+    private readonly Mock<ISettingsRepository> _settingsRepositoryMock = new();
     private readonly Mock<IAppLifecycleService> _lifecycleMock = new();
     private readonly FakeTimeProvider _clock = new();
 
@@ -17,13 +20,17 @@ public class DiscoveryRefreshServiceTests
         TimeSpan? pollingInterval = null,
         TimeSpan? debounceWindow = null)
     {
+        _settingsRepositoryMock.Setup(r => r.GetSettingsAsync())
+            .ReturnsAsync(NdiSettingsSnapshot.CreateDefault());
+
         return new DiscoveryRefreshService(
-            repository:      _repositoryMock.Object,
-            lifecycle:       _lifecycleMock.Object,
-            logger:          NullLogger<DiscoveryRefreshService>.Instance,
-            timeProvider:    _clock,
-            pollingInterval: pollingInterval ?? TimeSpan.FromMilliseconds(50),
-            debounceWindow:  debounceWindow  ?? TimeSpan.FromMilliseconds(10));
+            repository:         _repositoryMock.Object,
+            settingsRepository: _settingsRepositoryMock.Object,
+            lifecycle:          _lifecycleMock.Object,
+            logger:             NullLogger<DiscoveryRefreshService>.Instance,
+            timeProvider:       _clock,
+            pollingInterval:    pollingInterval ?? TimeSpan.FromMilliseconds(50),
+            debounceWindow:     debounceWindow  ?? TimeSpan.FromMilliseconds(10));
     }
 
     private DiscoverySnapshot OkSnapshot() => new(


### PR DESCRIPTION
## Problem
NDI **Discovery Server** mode never worked on device. A configured discovery server was ignored and discovery silently fell back to mDNS, so sources registered *only* with a discovery server were never found. Three independent defects combined:

### 1. Native env var not set (`NDI_CONFIG_DIR`)
`NdiRuntime` pointed libndi at its `ndi-config.v1.json` via managed `Environment.SetEnvironmentVariable`, which only updates the CLR cache — libndi's native `getenv` never sees it (and a libc `setenv` P/Invoke does not resolve on the Android MonoVM: *"Shared library 'libc'/'c' not loaded"*). Fixed by setting it through **`Android.Systems.Os.Setenv`** — a JNI call that mutates the real process environment — both early in `MainActivity.OnCreate` (guards against a load-time read) and in `WriteConfigFileLocked` before `NDIlib_initialize`. Verified on-device that `Os.Getenv` reads the value back.

### 2. Discovery config applied too late
The discovery orchestrator (persisted settings → NDI runtime) was invoked **only when the Settings page loaded**, never at startup — so a normal launch initialized NDI with an empty discovery config (mDNS) and the reinit-gating kept it there. `DiscoveryRefreshService` now applies persisted settings **once, before the first discovery poll**, so the discovery server is configured before the finder's first `NDIlib_initialize`.

### 3. `p_extra_ips` misuse (masked the bug)
`NdiDiscoveryBridge` fed discovery-server IPs into the finder's `p_extra_ips`, which per the NDI SDK is for **direct source-host IPs** (machines running senders) — it probes those hosts for senders (finding none at a discovery server) and can make a broken discovery-server config appear to work when a source host is entered. Discovery servers belong only in `networks.discovery` (the config file); `p_extra_ips` is now left empty.

## Verification
On a physical arm64 device (Galaxy Tab, Android 16) against a real NDI Discovery Server at `192.168.0.70:5959`, with **only the discovery server configured** (not the source host):
- `NDIDBG` traces confirm `SetDiscoveryServers pending='192.168.0.70:5959'` now runs **before** the first `NDIlib_initialize` (previously `pending=''`).
- `/proc/net/tcp` shows the app holds an **established TCP connection to `192.168.0.70:5959`**.
- The source `DESKTOP-UVOLCRD (Test Pattern)` (`192.168.2.23:5961`) is discovered **through the registry** — impossible via `p_extra_ips` alone, proving the config path works.
- Full unit suite green (**235/235**), including an updated `DiscoveryRefreshServiceTests`.

## Notes
- Diagnostic logging used during investigation was removed; a `Log.Warn` remains in the `Os.Setenv` catch so a future native-setenv failure is diagnosable.
- Actually *viewing* a discovered source still requires the separate DI fix in #290 (`SQLiteAsyncConnection` registration) — the Watch crash is unrelated to discovery and tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)