### PR TITLE
fix(shell): survive navigation and teardown in themed chrome and auto-save (#296, #300)

### DIFF
--- a/src/Core/Features/Settings/Services/IAppearanceService.cs
+++ b/src/Core/Features/Settings/Services/IAppearanceService.cs
@@ -5,4 +5,12 @@ namespace NdiForAndroid.Features.Settings.Services;
 public interface IAppearanceService
 {
     void Apply(ThemeMode theme, AccentColorOption accentColor);
+
+    /// <summary>
+    /// Re-applies platform chrome colors (status-bar strip, toolbar background) using the
+    /// last applied theme. Called after Shell navigation because MAUI re-applies per-page
+    /// toolbar appearance, resetting the AppBarLayout background to template defaults (#296).
+    /// No-op before the first <see cref="Apply"/> and on platforms without such chrome.
+    /// </summary>
+    void ReapplyChrome() { }
 }

--- a/src/Core/Features/Settings/ViewModels/SettingsViewModel.cs
+++ b/src/Core/Features/Settings/ViewModels/SettingsViewModel.cs
@@ -42,6 +42,12 @@ public partial class SettingsViewModel : ObservableObject
     private DiscoveryServerItem? _editingDiscoveryServer;
     private bool _suppressAutoSave;
 
+    // Last valid theme/accent selection. MAUI RadioButton groups reset SelectedValue to
+    // null/empty when the page is torn down (navigation away, activity destroy); persisting
+    // from those transient values would overwrite the user's stored choice with defaults.
+    private ThemeMode _committedTheme = ThemeMode.System;
+    private AccentColorOption _committedAccent = AccentColorOption.Blue;
+
     private CancellationTokenSource? _statusMonitorCts;
     private volatile IReadOnlyList<DiscoveryServerItem> _statusTargets = Array.Empty<DiscoveryServerItem>();
     private int _statusCheckInFlight;
@@ -156,6 +162,8 @@ public partial class SettingsViewModel : ObservableObject
         _suppressAutoSave = true;
 
         DeveloperModeEnabled = settings.DeveloperModeEnabled;
+        _committedTheme = settings.ThemeMode;
+        _committedAccent = settings.AccentColor;
         SelectedThemeOption = ToThemeOption(settings.ThemeMode);
         SelectedAccentColor = settings.AccentColor.ToString();
 
@@ -442,13 +450,20 @@ public partial class SettingsViewModel : ObservableObject
 
     partial void OnSelectedThemeOptionChanged(string value)
     {
-        _ = value;
+        // Radio-group teardown pushes null/empty through the binding — never commit that.
+        if (string.IsNullOrWhiteSpace(value))
+            return;
+
+        _committedTheme = ParseThemeOption(value);
         _ = PersistAsync();
     }
 
     partial void OnSelectedAccentColorChanged(string value)
     {
-        _ = value;
+        if (string.IsNullOrWhiteSpace(value))
+            return;
+
+        _committedAccent = ParseAccentColorOption(value);
         _ = PersistAsync();
     }
 
@@ -493,11 +508,13 @@ public partial class SettingsViewModel : ObservableObject
         for (var index = 0; index < DiscoveryServers.Count; index++)
             discoveryServers.Add(DiscoveryServers[index].ToPreference(index));
 
+        // _committedTheme/_committedAccent (not the bound strings): the radio bindings can
+        // transiently hold null/empty during page teardown, which would parse as defaults.
         var snapshot = _validationService.Sanitize(new NdiSettingsSnapshot(
             DeveloperModeEnabled,
             _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
-            ParseThemeOption(SelectedThemeOption),
-            ParseAccentColorOption(SelectedAccentColor),
+            _committedTheme,
+            _committedAccent,
             discoveryServers));
 
         if (!_validationService.TryValidateForSave(snapshot, out var error))

--- a/src/MauiApp/AppShell.xaml.cs
+++ b/src/MauiApp/AppShell.xaml.cs
@@ -1,6 +1,7 @@
 using NdiForAndroid.Features.Navigation.Models;
 using NdiForAndroid.Features.Navigation.Services;
 using NdiForAndroid.Features.Navigation.ViewModels;
+using NdiForAndroid.Features.Settings.Services;
 using NdiForAndroid.Features.Viewer.Views;
 using NdiForAndroid.Services;
 
@@ -30,6 +31,7 @@ public partial class AppShell : Shell
     private readonly IAndroidOrientationBridge _orientationBridge;
     private readonly INavigationHandoffService _handoffService;
     private readonly IWindowSizeClassService _windowSizeClassService;
+    private readonly IAppearanceService _appearanceService;
 
     private PrimaryNavDestination _currentPrimaryDestination = PrimaryNavDestination.Home;
 
@@ -49,7 +51,8 @@ public partial class AppShell : Shell
         AdaptiveShellStateViewModel stateViewModel,
         IAndroidOrientationBridge orientationBridge,
         INavigationHandoffService handoffService,
-        IWindowSizeClassService windowSizeClassService)
+        IWindowSizeClassService windowSizeClassService,
+        IAppearanceService appearanceService)
     {
         InitializeComponent();
 
@@ -57,6 +60,7 @@ public partial class AppShell : Shell
         _orientationBridge = orientationBridge;
         _handoffService   = handoffService;
         _windowSizeClassService = windowSizeClassService;
+        _appearanceService = appearanceService;
 
         Routing.RegisterRoute("viewer", typeof(ViewerPage));
         Routing.RegisterRoute("diagnostic-log", typeof(Features.DiagOverlay.Views.DiagnosticLogPage));
@@ -229,6 +233,10 @@ public partial class AppShell : Shell
 
         _stateViewModel.SelectedDestination = to;
         UpdateRailHighlight(to);
+
+        // MAUI re-applies per-page toolbar appearance on navigation, resetting the
+        // AppBarLayout background to template defaults — restore the themed chrome (#296).
+        _appearanceService.ReapplyChrome();
     }
 
     private static PrimaryNavDestination? ParseDestination(string? location)

--- a/src/MauiApp/Features/Settings/Services/MauiAppearanceService.cs
+++ b/src/MauiApp/Features/Settings/Services/MauiAppearanceService.cs
@@ -16,12 +16,37 @@ namespace NdiForAndroid.Features.Settings.Services;
 /// </summary>
 public sealed class MauiAppearanceService : IAppearanceService
 {
+    // Last applied chrome state, so ReapplyChrome can restore it after Shell navigation
+    // re-applies per-page toolbar appearance (resets the AppBarLayout background, #296).
+    private static Palette? _lastPalette;
+    private static bool _lastIsLight;
+
     public void Apply(ThemeMode theme, AccentColorOption accentColor)
     {
         if (MainThread.IsMainThread)
             ApplyCore(theme, accentColor);
         else
             MainThread.BeginInvokeOnMainThread(() => ApplyCore(theme, accentColor));
+    }
+
+    public void ReapplyChrome()
+    {
+        if (_lastPalette is null)
+            return;
+
+        var palette = _lastPalette;
+        var isLight = _lastIsLight;
+
+        // Always queue (never run inline): the toolbar appearance tracker that resets the
+        // AppBarLayout background runs synchronously during navigation, and freshly created
+        // pages apply theirs once more after the Navigated event — a second, delayed pass
+        // wins that race without visible flicker.
+        MainThread.BeginInvokeOnMainThread(() => UpdateAndroidStatusBar(palette, isLight));
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(250).ConfigureAwait(false);
+            MainThread.BeginInvokeOnMainThread(() => UpdateAndroidStatusBar(palette, isLight));
+        });
     }
 
     private static void ApplyCore(ThemeMode theme, AccentColorOption accentColor)
@@ -47,6 +72,9 @@ public sealed class MauiAppearanceService : IAppearanceService
         UpdateResources(palette, accent);
         UpdateShell(palette, isLight);
         UpdateAndroidStatusBar(palette, isLight);
+
+        _lastPalette = palette;
+        _lastIsLight = isLight;
     }
 
     // ── Color palettes ──────────────────────────────────────────────

--- a/tests/MauiApp.Tests/Features/Settings/SettingsViewModelAutoSaveTests.cs
+++ b/tests/MauiApp.Tests/Features/Settings/SettingsViewModelAutoSaveTests.cs
@@ -104,6 +104,47 @@ public sealed class SettingsViewModelAutoSaveTests
     }
 
     [Fact]
+    public async Task SelectedThemeOption_ResetToNullOnTeardown_DoesNotPersist()
+    {
+        var sut = await CreateLoadedSutAsync();
+        sut.SelectedThemeOption = "Dark";
+        _repositoryMock.Invocations.Clear();
+
+        // MAUI radio groups push null/empty through the binding when the page unloads.
+        sut.SelectedThemeOption = null!;
+
+        _repositoryMock.Verify(r => r.SaveSettingsAsync(It.IsAny<NdiSettingsSnapshot>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task PersistAfterThemeReset_KeepsLastCommittedTheme()
+    {
+        var sut = await CreateLoadedSutAsync();
+        sut.SelectedThemeOption = "Dark";
+        sut.SelectedThemeOption = string.Empty; // teardown reset
+        _repositoryMock.Invocations.Clear();
+
+        // Any later save (e.g. a server toggle) must still carry the committed theme.
+        sut.NewServerHost = "10.0.0.9";
+        await sut.AddDiscoveryServerCommand.ExecuteAsync(null);
+
+        _repositoryMock.Verify(r => r.SaveSettingsAsync(
+            It.Is<NdiSettingsSnapshot>(s => s.ThemeMode == ThemeMode.Dark)), Times.Once);
+    }
+
+    [Fact]
+    public async Task SelectedAccentColor_ResetToEmptyOnTeardown_DoesNotPersist()
+    {
+        var sut = await CreateLoadedSutAsync();
+        sut.SelectedAccentColor = "Red";
+        _repositoryMock.Invocations.Clear();
+
+        sut.SelectedAccentColor = string.Empty;
+
+        _repositoryMock.Verify(r => r.SaveSettingsAsync(It.IsAny<NdiSettingsSnapshot>()), Times.Never);
+    }
+
+    [Fact]
     public async Task DeveloperModeEnabled_Changed_PersistsImmediately()
     {
         var sut = await CreateLoadedSutAsync();


### PR DESCRIPTION
@-