### PR TITLE
fix(ui): theme-aware nav rail icons, status-bar inset, settings teardown guard

### DIFF
--- a/src/Core/Features/Navigation/Models/PrimaryNavigationMetadata.cs
+++ b/src/Core/Features/Navigation/Models/PrimaryNavigationMetadata.cs
@@ -20,19 +20,48 @@ public enum DeviceOrientation
     Landscape,
 }
 
+/// <param name="IconKey">
+/// Bundled SVG used by the Shell tab bar, which tints icons natively from
+/// <c>Shell.TabBarForegroundColor</c>.
+/// </param>
+/// <param name="IconGeometry">
+/// The same glyph as SVG path mini-language, drawn on a 24x24 canvas. The left rail renders
+/// this as a vector shape it can fill with the current theme color — the bundled SVGs carry a
+/// baked-in white fill and cannot be re-tinted at runtime (#294).
+/// </param>
 public sealed record PrimaryNavItem(
     PrimaryNavDestination Destination,
     string Label,
     string Route,
-    string IconKey);
+    string IconKey,
+    string IconGeometry);
 
 public static class PrimaryNavigationMetadata
 {
+    private const string HomeGeometry =
+        "M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z";
+
+    private const string StreamGeometry =
+        "M17 10.5V7c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4z";
+
+    private const string ViewGeometry =
+        "M21 3H3c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h5v2h8v-2h5c1.1 0 1.99-.9 1.99-2L23 5c0-1.1-.9-2-2-2zm0 14H3V5h18v12z";
+
+    private const string SettingsGeometry =
+        "M19.14,12.94c0.04-0.3,0.06-0.61,0.06-0.94c0-0.32-0.02-0.64-0.07-0.94l2.03-1.58c0.18-0.14,0.23-0.41,0.12-0.61 " +
+        "l-1.92-3.32c-0.12-0.22-0.37-0.29-0.59-0.22l-2.39,0.96c-0.5-0.38-1.03-0.7-1.62-0.94L14.4,2.81c-0.04-0.24-0.24-0.41-0.48-0.41 " +
+        "h-3.84c-0.24,0-0.43,0.17-0.47,0.41L9.25,5.35C8.66,5.59,8.12,5.92,7.63,6.29L5.24,5.33c-0.22-0.08-0.47,0-0.59,0.22L2.74,8.87 " +
+        "C2.62,9.08,2.66,9.34,2.86,9.48l2.03,1.58C4.84,11.36,4.8,11.69,4.8,12s0.02,0.64,0.07,0.94l-2.03,1.58 " +
+        "c-0.18,0.14-0.23,0.41-0.12,0.61l1.92,3.32c0.12,0.22,0.37,0.29,0.59,0.22l2.39-0.96c0.5,0.38,1.03,0.7,1.62,0.94l0.36,2.54 " +
+        "c0.05,0.24,0.24,0.41,0.48,0.41h3.84c0.24,0,0.44-0.17,0.47-0.41l0.36-2.54c0.59-0.24,1.13-0.56,1.62-0.94l2.39,0.96 " +
+        "c0.22,0.08,0.47,0,0.59-0.22l1.92-3.32c0.12-0.22,0.07-0.47-0.12-0.61L19.14,12.94z M12,15.6c-1.98,0-3.6-1.62-3.6-3.6 " +
+        "s1.62-3.6,3.6-3.6s3.6,1.62,3.6,3.6S13.98,15.6,12,15.6z";
+
     public static readonly IReadOnlyList<PrimaryNavItem> Items =
     [
-        new(PrimaryNavDestination.Home, "Home", "//home", "nav_home.svg"),
-        new(PrimaryNavDestination.Stream, "Stream", "//stream", "nav_stream.svg"),
-        new(PrimaryNavDestination.View, "View", "//view", "nav_view.svg"),
-        new(PrimaryNavDestination.Settings, "Settings", "//settings", "nav_settings.svg"),
+        new(PrimaryNavDestination.Home, "Home", "//home", "nav_home.svg", HomeGeometry),
+        new(PrimaryNavDestination.Stream, "Stream", "//stream", "nav_stream.svg", StreamGeometry),
+        new(PrimaryNavDestination.View, "View", "//view", "nav_view.svg", ViewGeometry),
+        new(PrimaryNavDestination.Settings, "Settings", "//settings", "nav_settings.svg", SettingsGeometry),
     ];
 }

--- a/src/Core/Features/Settings/Services/IAppearanceService.cs
+++ b/src/Core/Features/Settings/Services/IAppearanceService.cs
@@ -5,4 +5,11 @@ namespace NdiForAndroid.Features.Settings.Services;
 public interface IAppearanceService
 {
     void Apply(ThemeMode theme, AccentColorOption accentColor);
+
+    /// <summary>
+    /// Raised on the UI thread after <see cref="Apply"/> has written the new palette to the
+    /// application resources. Chrome that is built in code — and therefore cannot listen to
+    /// <c>DynamicResource</c> — subscribes to this to re-read its colors (#294).
+    /// </summary>
+    event EventHandler? AppearanceChanged;
 }

--- a/src/Core/Features/Settings/ViewModels/SettingsViewModel.cs
+++ b/src/Core/Features/Settings/ViewModels/SettingsViewModel.cs
@@ -52,11 +52,17 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private bool _developerModeEnabled;
 
+    // Nullable because the view can write null back: RadioButtonGroup.SelectedValue pushes null
+    // through its two-way binding while the Settings page's visual tree is being torn down.
+    // The change handlers below reject those writes — see _lastValid* .
     [ObservableProperty]
-    private string _selectedThemeOption = ThemeSystemLabel;
+    private string? _selectedThemeOption = ThemeSystemLabel;
 
     [ObservableProperty]
-    private string _selectedAccentColor = AccentColorOption.Blue.ToString();
+    private string? _selectedAccentColor = AccentColorOption.Blue.ToString();
+
+    private string _lastValidThemeOption = ThemeSystemLabel;
+    private string _lastValidAccentColor = AccentColorOption.Blue.ToString();
 
     [ObservableProperty]
     private string _discoveryServerEndpointInput = string.Empty;
@@ -354,19 +360,40 @@ public partial class SettingsViewModel : ObservableObject
         RefreshPendingState();
     }
 
-    partial void OnSelectedThemeOptionChanged(string value)
+    partial void OnSelectedThemeOptionChanged(string? value)
     {
-        _ = value;
+        // Tearing the page down must not read as the user picking a theme. Without this, the
+        // null that RadioButtonGroup writes on teardown parses to the default (System) and
+        // gets staged as a real edit — so any save then persists the default over the user's
+        // actual choice (#300). Restore the last real selection and stay clean.
+        if (!IsKnownOption(ThemeOptions, value))
+        {
+            SelectedThemeOption = _lastValidThemeOption;
+            return;
+        }
+
+        _lastValidThemeOption = value!;
         IsApplied = false;
         RefreshPendingState();
     }
 
-    partial void OnSelectedAccentColorChanged(string value)
+    partial void OnSelectedAccentColorChanged(string? value)
     {
-        _ = value;
+        // Same teardown guard as the theme selection above.
+        if (!IsKnownOption(AccentColorOptions, value))
+        {
+            SelectedAccentColor = _lastValidAccentColor;
+            return;
+        }
+
+        _lastValidAccentColor = value!;
         IsApplied = false;
         RefreshPendingState();
     }
+
+    private static bool IsKnownOption(IReadOnlyList<string> options, string? value)
+        => !string.IsNullOrWhiteSpace(value)
+           && options.Contains(value, StringComparer.OrdinalIgnoreCase);
 
     private bool CanApply()
     {

--- a/src/Core/Services/IWindowInsetsService.cs
+++ b/src/Core/Services/IWindowInsetsService.cs
@@ -1,0 +1,19 @@
+namespace NdiForAndroid.Services;
+
+/// <summary>
+/// Exposes the system-bar insets of the current window in device-independent units.
+/// </summary>
+/// <remarks>
+/// The app draws edge-to-edge (<c>SetDecorFitsSystemWindows(false)</c> in <c>MainActivity</c>),
+/// so chrome anchored to the top of the window renders <em>behind</em> the status bar unless it
+/// is inset by hand. Non-Android targets have no system bars and report zero.
+/// </remarks>
+public interface IWindowInsetsService
+{
+    /// <summary>
+    /// Height of the status bar in device-independent units, or <c>0</c> when there is none
+    /// (or it cannot be resolved yet). Read it late — the value is only reliable once the
+    /// window has been laid out.
+    /// </summary>
+    double GetStatusBarInset();
+}

--- a/src/MauiApp/AppShell.xaml
+++ b/src/MauiApp/AppShell.xaml
@@ -9,20 +9,21 @@
        x:Class="NdiForAndroid.AppShell"
        Shell.FlyoutBehavior="Disabled"
        Shell.FlyoutWidth="72"
-       Shell.FlyoutBackgroundColor="#1C1C1E"
-       Shell.TabBarBackgroundColor="#1C1C1E"
-       Shell.TabBarForegroundColor="#FFFFFF"
-       Shell.TabBarTitleColor="#FFFFFF"
-       Shell.TabBarUnselectedColor="#8E8E93"
+       Shell.FlyoutBackgroundColor="{DynamicResource ShellBackground}"
+       Shell.TabBarBackgroundColor="{DynamicResource ShellBackground}"
+       Shell.TabBarForegroundColor="{DynamicResource ShellTabSelected}"
+       Shell.TabBarTitleColor="{DynamicResource ShellTabSelected}"
+       Shell.TabBarUnselectedColor="{DynamicResource ShellTabUnselected}"
        Title="NDI for Android">
 
     <!-- Custom left navigation rail. FlyoutHeaderTemplate intentionally omitted:
-         setting it alongside FlyoutContent triggers a MAUI compat renderer NRE. -->
+         setting it alongside FlyoutContent triggers a MAUI compat renderer NRE.
+         RailItems.Padding is set in code-behind from the real status-bar inset (#296) —
+         the window is drawn edge-to-edge, so a literal top padding would sit under the clock. -->
     <Shell.FlyoutContent>
-        <Grid BackgroundColor="#1C1C1E" WidthRequest="64">
+        <Grid BackgroundColor="{DynamicResource ShellBackground}" WidthRequest="64">
             <VerticalStackLayout x:Name="RailItems"
                                  VerticalOptions="Start"
-                                 Padding="0,24,0,0"
                                  Spacing="0" />
         </Grid>
     </Shell.FlyoutContent>

--- a/src/MauiApp/AppShell.xaml.cs
+++ b/src/MauiApp/AppShell.xaml.cs
@@ -1,8 +1,15 @@
 using NdiForAndroid.Features.Navigation.Models;
 using NdiForAndroid.Features.Navigation.Services;
 using NdiForAndroid.Features.Navigation.ViewModels;
+using NdiForAndroid.Features.Settings.Services;
 using NdiForAndroid.Features.Viewer.Views;
 using NdiForAndroid.Services;
+
+// Aliased rather than importing Microsoft.Maui.Controls.Shapes wholesale: its Path would
+// collide with System.IO.Path, which the SDK's implicit usings already bring in.
+using Geometry = Microsoft.Maui.Controls.Shapes.Geometry;
+using Path = Microsoft.Maui.Controls.Shapes.Path;
+using PathGeometryConverter = Microsoft.Maui.Controls.Shapes.PathGeometryConverter;
 
 namespace NdiForAndroid;
 
@@ -30,10 +37,15 @@ public partial class AppShell : Shell
     private readonly IAndroidOrientationBridge _orientationBridge;
     private readonly INavigationHandoffService _handoffService;
     private readonly IWindowSizeClassService _windowSizeClassService;
+    private readonly IWindowInsetsService _windowInsetsService;
+    private readonly IAppearanceService _appearanceService;
 
     private PrimaryNavDestination _currentPrimaryDestination = PrimaryNavDestination.Home;
 
-    private readonly Dictionary<PrimaryNavDestination, (Border Container, Label Label, Image Icon)> _railButtons = [];
+    private readonly Dictionary<PrimaryNavDestination, (Border Container, Label Label, Path Icon)> _railButtons = [];
+
+    /// <summary>Rendered edge length of a rail icon, in device-independent units.</summary>
+    private const double RailIconSize = 28d;
 
     // Rail text colors come from the shared theme palette (Colors.xaml) so the rail
     // matches the tab bar; resolved per-use so appearance/theme changes are honored.
@@ -49,7 +61,9 @@ public partial class AppShell : Shell
         AdaptiveShellStateViewModel stateViewModel,
         IAndroidOrientationBridge orientationBridge,
         INavigationHandoffService handoffService,
-        IWindowSizeClassService windowSizeClassService)
+        IWindowSizeClassService windowSizeClassService,
+        IWindowInsetsService windowInsetsService,
+        IAppearanceService appearanceService)
     {
         InitializeComponent();
 
@@ -57,6 +71,8 @@ public partial class AppShell : Shell
         _orientationBridge = orientationBridge;
         _handoffService   = handoffService;
         _windowSizeClassService = windowSizeClassService;
+        _windowInsetsService = windowInsetsService;
+        _appearanceService = appearanceService;
 
         Routing.RegisterRoute("viewer", typeof(ViewerPage));
         Routing.RegisterRoute("diagnostic-log", typeof(Features.DiagOverlay.Views.DiagnosticLogPage));
@@ -67,6 +83,10 @@ public partial class AppShell : Shell
         _stateViewModel.PropertyChanged += OnStatePropertyChanged;
         _stateViewModel.RailItemSelected += OnRailItemSelected;
         Navigated += OnShellNavigated;
+
+        // The rail is built in code, so DynamicResource cannot reach it — re-tint on every
+        // palette change instead, otherwise the icons keep the previous theme's color (#294).
+        _appearanceService.AppearanceChanged += OnAppearanceChanged;
 
         _orientationBridge.SyncFromDisplayInfo();
         ApplyPlacement();
@@ -82,6 +102,32 @@ public partial class AppShell : Shell
 
         if (width > 0)
             _windowSizeClassService.UpdateFromWidth(width);
+
+        // Insets resolve only once the window is laid out, and change on rotation or when a
+        // cutout enters/leaves the top edge — so re-read them here rather than at construction.
+        ApplyRailInset();
+    }
+
+    private void OnAppearanceChanged(object? sender, EventArgs e)
+    {
+        _ = sender;
+        _ = e;
+        UpdateRailHighlight(_currentPrimaryDestination);
+    }
+
+    /// <summary>
+    /// Pushes the rail's first item below the status bar. The window is drawn edge-to-edge, so
+    /// without this the rail's background — and its topmost item — sit under the clock (#296).
+    /// </summary>
+    private void ApplyRailInset()
+    {
+        var topInset = _windowInsetsService.GetStatusBarInset();
+        if (topInset < 0)
+            topInset = 0;
+
+        var padding = new Thickness(0, topInset, 0, 0);
+        if (RailItems.Padding != padding)
+            RailItems.Padding = padding;
     }
 
     // ── Rail construction ────────────────────────────────────────────────────
@@ -90,12 +136,16 @@ public partial class AppShell : Shell
     {
         foreach (var item in PrimaryNavigationMetadata.Items)
         {
-            var icon = new Image
+            // A vector Path rather than an Image: the bundled SVGs bake in a white fill, and
+            // MAUI's Image has no tint, so an icon built from one cannot follow the theme (#294).
+            var icon = new Path
             {
-                Source = item.IconKey,
-                HeightRequest = 28,
-                WidthRequest  = 28,
+                Data = (Geometry)new PathGeometryConverter().ConvertFromInvariantString(item.IconGeometry)!,
+                Aspect = Microsoft.Maui.Controls.Stretch.Uniform,
+                HeightRequest = RailIconSize,
+                WidthRequest  = RailIconSize,
                 HorizontalOptions = LayoutOptions.Center,
+                Fill = new SolidColorBrush(InactiveText),
             };
 
             var label = new Label
@@ -139,12 +189,18 @@ public partial class AppShell : Shell
 
     private void UpdateRailHighlight(PrimaryNavDestination active)
     {
+        // Resolved once per pass so a theme change picks up the new palette.
+        var activeText   = ActiveText;
+        var inactiveText = InactiveText;
+
         foreach (var kvp in _railButtons)
         {
             bool isActive = kvp.Key == active;
+            var foreground = isActive ? activeText : inactiveText;
+
             kvp.Value.Container.BackgroundColor = Colors.Transparent;
-            kvp.Value.Label.TextColor = isActive ? ActiveText : InactiveText;
-            kvp.Value.Icon.Opacity    = isActive ? 1.0 : 0.62;
+            kvp.Value.Label.TextColor = foreground;
+            kvp.Value.Icon.Fill       = new SolidColorBrush(foreground);
         }
     }
 

--- a/src/MauiApp/Features/Settings/Services/MauiAppearanceService.cs
+++ b/src/MauiApp/Features/Settings/Services/MauiAppearanceService.cs
@@ -16,6 +16,8 @@ namespace NdiForAndroid.Features.Settings.Services;
 /// </summary>
 public sealed class MauiAppearanceService : IAppearanceService
 {
+    public event EventHandler? AppearanceChanged;
+
     public void Apply(ThemeMode theme, AccentColorOption accentColor)
     {
         if (MainThread.IsMainThread)
@@ -24,7 +26,7 @@ public sealed class MauiAppearanceService : IAppearanceService
             MainThread.BeginInvokeOnMainThread(() => ApplyCore(theme, accentColor));
     }
 
-    private static void ApplyCore(ThemeMode theme, AccentColorOption accentColor)
+    private void ApplyCore(ThemeMode theme, AccentColorOption accentColor)
     {
         if (Application.Current is null)
             return;
@@ -47,6 +49,9 @@ public sealed class MauiAppearanceService : IAppearanceService
         UpdateResources(palette, accent);
         UpdateShell(palette);
         UpdateAndroidStatusBar(palette, isLight);
+
+        // Fires last: subscribers re-read the resource dictionary this call just rewrote.
+        AppearanceChanged?.Invoke(this, EventArgs.Empty);
     }
 
     // ── Color palettes ──────────────────────────────────────────────

--- a/src/MauiApp/MauiProgram.cs
+++ b/src/MauiApp/MauiProgram.cs
@@ -104,6 +104,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<IAudioPlaybackSink, AndroidAudioPlaybackSink>();
         builder.Services.AddSingleton<IVideoCaptureSource, AndroidVideoCaptureSource>();
         builder.Services.AddSingleton<IAudioCaptureSource, AndroidMicrophoneCaptureSource>();
+        builder.Services.AddSingleton<IWindowInsetsService, AndroidWindowInsetsService>();
 #else
         builder.Services.AddSingleton<IMulticastLockService, NoopMulticastLockService>();
         builder.Services.AddSingleton<IScreenSharePlatformService, NoopScreenSharePlatformService>();
@@ -112,6 +113,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<IAudioPlaybackSink, NoopAudioPlaybackSink>();
         builder.Services.AddSingleton<IVideoCaptureSource, NoopVideoCaptureSource>();
         builder.Services.AddSingleton<IAudioCaptureSource, NoopAudioCaptureSource>();
+        builder.Services.AddSingleton<IWindowInsetsService, NoopWindowInsetsService>();
 #endif
 
         // ViewModels

--- a/src/MauiApp/Platforms/Android/Services/AndroidWindowInsetsService.cs
+++ b/src/MauiApp/Platforms/Android/Services/AndroidWindowInsetsService.cs
@@ -1,0 +1,46 @@
+using AndroidX.Core.View;
+using NdiForAndroid.Services;
+
+namespace NdiForAndroid.Platforms.Android.Services;
+
+/// <summary>
+/// Reads the real status-bar inset from the current window.
+/// </summary>
+public sealed class AndroidWindowInsetsService : IWindowInsetsService
+{
+    public double GetStatusBarInset()
+    {
+        var activity = Platform.CurrentActivity;
+        var decorView = activity?.Window?.DecorView;
+        if (decorView is null)
+            return 0d;
+
+        var density = activity!.Resources?.DisplayMetrics?.Density ?? 0f;
+        if (density <= 0f)
+            return 0d;
+
+        var insetPixels = ResolveStatusBarInsetPixels(decorView, activity);
+        return insetPixels <= 0 ? 0d : insetPixels / density;
+    }
+
+    private static int ResolveStatusBarInsetPixels(
+        global::Android.Views.View decorView,
+        global::Android.App.Activity activity)
+    {
+        // Preferred source: the live insets attached to the view tree. Null until the window
+        // has been attached and laid out, which is why the dimen fallback below exists.
+        var rootInsets = ViewCompat.GetRootWindowInsets(decorView);
+        var statusBarInset = rootInsets?.GetInsets(WindowInsetsCompat.Type.StatusBars())?.Top ?? 0;
+        if (statusBarInset > 0)
+            return statusBarInset;
+
+        // Fallback: the platform's declared status-bar height. Always resolvable, but it does
+        // not account for display cutouts, so it is only used before the first layout pass.
+        var resources = activity.Resources;
+        if (resources is null)
+            return 0;
+
+        var resourceId = resources.GetIdentifier("status_bar_height", "dimen", "android");
+        return resourceId > 0 ? resources.GetDimensionPixelSize(resourceId) : 0;
+    }
+}

--- a/src/MauiApp/Services/NoopWindowInsetsService.cs
+++ b/src/MauiApp/Services/NoopWindowInsetsService.cs
@@ -1,0 +1,9 @@
+namespace NdiForAndroid.Services;
+
+/// <summary>
+/// Non-Android fallback: no system bars, so nothing to inset.
+/// </summary>
+public sealed class NoopWindowInsetsService : IWindowInsetsService
+{
+    public double GetStatusBarInset() => 0d;
+}

--- a/tests/MauiApp.Tests/Features/Navigation/AdaptiveNavigationTests.cs
+++ b/tests/MauiApp.Tests/Features/Navigation/AdaptiveNavigationTests.cs
@@ -50,6 +50,24 @@ public sealed class PrimaryNavigationMetadataTests
         Assert.Equal(items.Count, items.Select(i => i.Route).Distinct().Count());
         Assert.All(items, item => Assert.StartsWith("//", item.Route));
     }
+
+    /// <summary>
+    /// The rail renders <see cref="PrimaryNavItem.IconGeometry"/> as a themeable vector (#294);
+    /// a missing or malformed value would throw while the rail is being built.
+    /// </summary>
+    [Fact]
+    public void Items_HaveDistinctIconGeometry_StartingWithAMoveCommand()
+    {
+        var items = PrimaryNavigationMetadata.Items;
+
+        Assert.All(items, item =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(item.IconGeometry));
+            Assert.StartsWith("M", item.IconGeometry, StringComparison.OrdinalIgnoreCase);
+        });
+
+        Assert.Equal(items.Count, items.Select(i => i.IconGeometry).Distinct().Count());
+    }
 }
 
 public sealed class NavigationPolicyServiceTests

--- a/tests/MauiApp.Tests/Features/Settings/SettingsViewModelTeardownGuardTests.cs
+++ b/tests/MauiApp.Tests/Features/Settings/SettingsViewModelTeardownGuardTests.cs
@@ -1,0 +1,175 @@
+using Moq;
+using NdiForAndroid.Features.Settings.Models;
+using NdiForAndroid.Features.Settings.Repositories;
+using NdiForAndroid.Features.Settings.Services;
+using NdiForAndroid.Features.Settings.ViewModels;
+using NdiForAndroid.Features.Sources.Repositories;
+using NdiForAndroid.Services;
+using Xunit;
+
+namespace NdiForAndroid.Tests.Features.Settings;
+
+/// <summary>
+/// Regression tests for #300 — tearing the Settings page down must not be mistaken for the
+/// user changing the theme.
+/// </summary>
+/// <remarks>
+/// <c>RadioButtonGroup.SelectedValue</c> writes <c>null</c> back through its two-way binding
+/// while the page's visual tree unloads. Left unguarded that null parses to the default
+/// (<see cref="ThemeMode.System"/>) and is staged as a real edit, so any save that follows
+/// persists the default theme over whatever the user actually picked.
+/// </remarks>
+public sealed class SettingsViewModelTeardownGuardTests
+{
+    private readonly Mock<ISettingsRepository> _repositoryMock = new();
+    private readonly ISettingsValidationService _validationService = new SettingsValidationService();
+    private readonly Mock<ISettingsPlatformService> _platformServiceMock = new();
+    private readonly Mock<ISourceRepository> _sourceRepositoryMock = new();
+
+    private SettingsViewModel CreateSut()
+    {
+        _platformServiceMock
+            .Setup(s => s.GetAppInfo())
+            .Returns(new SettingsAppInfo("NDI for Android", "2.0.0", "42"));
+
+        _sourceRepositoryMock
+            .Setup(r => r.GetCachedSourcesAsync())
+            .ReturnsAsync(Array.Empty<NdiForAndroid.Features.Sources.Models.NdiSource>());
+
+        return new SettingsViewModel(
+            _repositoryMock.Object,
+            _validationService,
+            _platformServiceMock.Object,
+            _sourceRepositoryMock.Object,
+            new Mock<INdiVersionInfo>().Object);
+    }
+
+    /// <summary>Loads a persisted snapshot whose theme is an explicit, non-default choice.</summary>
+    private async Task<SettingsViewModel> CreateLoadedWithLightThemeAsync()
+    {
+        var saved = NdiSettingsSnapshot.CreateDefault() with
+        {
+            ThemeMode = ThemeMode.Light,
+            AccentColor = AccentColorOption.Teal,
+        };
+
+        _repositoryMock.Setup(r => r.GetSettingsAsync()).ReturnsAsync(saved);
+
+        var sut = CreateSut();
+        await sut.LoadCommand.ExecuteAsync(null);
+        return sut;
+    }
+
+    // ─── Theme ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SelectedThemeOption_SetToNullByTeardown_KeepsUserSelection()
+    {
+        var sut = await CreateLoadedWithLightThemeAsync();
+
+        sut.SelectedThemeOption = null;
+
+        Assert.Equal("Light", sut.SelectedThemeOption);
+    }
+
+    [Fact]
+    public async Task SelectedThemeOption_SetToNullByTeardown_DoesNotStagePendingChanges()
+    {
+        var sut = await CreateLoadedWithLightThemeAsync();
+
+        sut.SelectedThemeOption = null;
+
+        Assert.False(sut.HasPendingChanges);
+    }
+
+    [Fact]
+    public async Task SelectedThemeOption_SetToNullByTeardown_LeavesApplyDisabled()
+    {
+        var sut = await CreateLoadedWithLightThemeAsync();
+
+        sut.SelectedThemeOption = null;
+
+        Assert.False(sut.ApplyCommand.CanExecute(null));
+    }
+
+    /// <summary>The defect's payload: a save after teardown must not write the default theme.</summary>
+    [Fact]
+    public async Task ApplyAfterTeardownNull_DoesNotPersistDefaultTheme()
+    {
+        var sut = await CreateLoadedWithLightThemeAsync();
+        NdiSettingsSnapshot? persisted = null;
+        _repositoryMock
+            .Setup(r => r.SaveSettingsAsync(It.IsAny<NdiSettingsSnapshot>()))
+            .Callback<NdiSettingsSnapshot>(snapshot => persisted = snapshot)
+            .Returns(Task.CompletedTask);
+
+        sut.SelectedThemeOption = null;
+        // A genuine, unrelated edit so Apply is reachable.
+        sut.DiscoveryHost = "10.0.0.99";
+        await sut.ApplyCommand.ExecuteAsync(null);
+
+        Assert.NotNull(persisted);
+        Assert.Equal(ThemeMode.Light, persisted!.ThemeMode);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Sepia")]
+    public async Task SelectedThemeOption_SetToUnknownValue_KeepsUserSelection(string value)
+    {
+        var sut = await CreateLoadedWithLightThemeAsync();
+
+        sut.SelectedThemeOption = value;
+
+        Assert.Equal("Light", sut.SelectedThemeOption);
+        Assert.False(sut.HasPendingChanges);
+    }
+
+    [Fact]
+    public async Task SelectedThemeOption_SetToRealChoice_StillStagesPendingChanges()
+    {
+        var sut = await CreateLoadedWithLightThemeAsync();
+
+        sut.SelectedThemeOption = "Dark";
+
+        Assert.Equal("Dark", sut.SelectedThemeOption);
+        Assert.True(sut.HasPendingChanges);
+    }
+
+    [Fact]
+    public async Task SelectedThemeOption_RestoredAfterTeardown_StillAcceptsNextRealChange()
+    {
+        var sut = await CreateLoadedWithLightThemeAsync();
+
+        sut.SelectedThemeOption = null;
+        sut.SelectedThemeOption = "Dark";
+
+        Assert.Equal("Dark", sut.SelectedThemeOption);
+        Assert.True(sut.HasPendingChanges);
+    }
+
+    // ─── Accent color ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SelectedAccentColor_SetToNullByTeardown_KeepsUserSelection()
+    {
+        var sut = await CreateLoadedWithLightThemeAsync();
+
+        sut.SelectedAccentColor = null;
+
+        Assert.Equal("Teal", sut.SelectedAccentColor);
+        Assert.False(sut.HasPendingChanges);
+    }
+
+    [Fact]
+    public async Task SelectedAccentColor_SetToRealChoice_StillStagesPendingChanges()
+    {
+        var sut = await CreateLoadedWithLightThemeAsync();
+
+        sut.SelectedAccentColor = "Orange";
+
+        Assert.Equal("Orange", sut.SelectedAccentColor);
+        Assert.True(sut.HasPendingChanges);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the three open theming/navigation bugs: #294, #296, #300.

All three issue bodies were empty (`@-`), so the root causes below were derived from the titles plus the code. **Please sanity-check the #300 interpretation in particular** — see the note at the bottom.

**#294 — Rail navigation icons stay white after switching to light theme**
Impacted: `AppShell.xaml.cs`, `AppShell.xaml`, `PrimaryNavigationMetadata.cs`, `IAppearanceService.cs`, `MauiAppearanceService.cs`

The rail rendered its icons as `Image` elements sourced from the bundled SVGs, which bake in `fill="#ffffff"`. MAUI's `Image` has no tint, so on a light rail (`ShellBackground` → `#E5E5EA`) the glyphs stayed white. Two changes:

- Icons are now `Microsoft.Maui.Controls.Shapes.Path` elements built from the same glyph geometry (moved into `PrimaryNavItem.IconGeometry`), filled from `ShellTabSelected` / `ShellTabUnselected`. The SVGs are kept for the bottom tab bar, which Shell tints natively.
- The rail is built in code, so `DynamicResource` can't reach it. `IAppearanceService` gained an `AppearanceChanged` event, raised after the palette is written; `AppShell` subscribes and re-tints. Without this the rail kept the previous theme's colors until the next navigation — which also affected the labels, not just the icons.

Active/inactive state is now carried by color alone rather than stacking a `0.62` opacity dim on top of the already-dimmer unselected color.

**#296 — Rail navigation background extends under the status bar (clock)**
Impacted: `IWindowInsetsService.cs` (new), `AndroidWindowInsetsService.cs` (new), `NoopWindowInsetsService.cs` (new), `AppShell.xaml`, `AppShell.xaml.cs`, `MauiProgram.cs`

`MainActivity` draws edge-to-edge (`SetDecorFitsSystemWindows(false)`), and the rail compensated with a literal `Padding="0,24,0,0"` that matches no real device inset. Replaced with the actual status-bar inset behind a Core interface: the Android implementation reads the live `WindowInsetsCompat`, falling back to the platform `status_bar_height` dimen before the first layout pass; non-Android targets report `0`. Applied from `OnSizeAllocated` so rotation and cutout changes are picked up.

**#300 — Auto-save persists default theme when Settings page is torn down**
Impacted: `SettingsViewModel.cs`

`RadioButtonGroup.SelectedValue` writes `null` back through its two-way binding as the Settings page's visual tree unloads. That null flowed into `SelectedThemeOption`, where `ParseThemeOption(null)` silently mapped it to the default `ThemeMode.System` and dirty-tracking staged it as a genuine user edit. Any save that followed would therefore persist the default theme over the user's actual choice. The theme and accent handlers now reject values outside their option lists and restore the last real selection, so a teardown leaves the page clean.

Also replaced the hardcoded hex Shell chrome colors in `AppShell.xaml` with `DynamicResource`, per the project's theming rules.

## Validation

- [x] Unit tests executed — **247 passed, 0 failed, 0 skipped** ([run](https://github.com/nielsverhoeven/NDI-for-Android/actions/runs/31648954961/job/94288845510))
- [ ] Instrumentation/UI tests executed — **not run**; the emulator job is gated on `github.ref == 'refs/heads/main'`, so it does not execute for this PR
- [x] Release build validation executed — `Build App (Release)` compiled the Android head with **0 errors** (7 pre-existing `XC0025` binding warnings in `SourceListPage.xaml`, untouched by this change)

Tests added:
- `SettingsViewModelTeardownGuardTests` — 11 cases covering the #300 guard: a teardown null keeps the user's selection, leaves `HasPendingChanges` false and Apply disabled, does not persist the default theme on a later save, and still accepts genuine changes afterwards.
- `PrimaryNavigationMetadataTests.Items_HaveDistinctIconGeometry_StartingWithAMoveCommand` — guards against a nav item shipping without geometry, which would throw while the rail is built.

**Still unverified: #294 and #296 have not been checked on a device.** Both are purely visual, and neither is covered by any automated check that runs on this PR. They need a look in light *and* dark theme, and in both orientations (the rail only appears in the Expanded size class), ideally on a device with a display cutout. This is the one gap I could not close — the session this was written in had no device and no emulator.

## TDD Evidence (Required)

- [ ] Failing-test evidence links included (before implementation)
- [ ] Passing-test evidence links included (after implementation)
- [ ] Story evidence artifacts linked

Not applicable in the form the template asks for: no .NET SDK was available in the authoring environment, so no local test run exists on either side of the change. The post-implementation evidence is the CI run linked above.

## Governance Checks

- [x] No unauthorized permission additions — no manifest or permission changes
- [x] Toolchain blocker status reviewed — no repo toolchain change; the missing SDK was a limitation of the authoring session only
- [x] Design-language and lifecycle safety checks — the rail now follows the shared palette instead of hardcoded hex; `AppShell` is a DI singleton for the app's lifetime, so its `AppearanceChanged` subscription is not an unbounded-growth leak

## Reviewer note on #300

The title says "auto-save", but there is no auto-save path in `main` today — `SettingsViewModel` is Apply-gated, and the only writers are `ApplyAsync` and `SettingsRepository.SaveSettingsAsync`. What I fixed is the latent defect the title describes: teardown corrupting the staged theme so a save persists the default. If you were actually seeing this against the immediate-save behavior proposed in #292, this guard is the right foundation for it, but the trigger would live in that work. Worth confirming.