### PR TITLE
chore(dev): add SessionStart hook to provision the .NET SDK for web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+#
+# SessionStart hook — provisions the .NET SDK for Claude Code on the web.
+#
+# Web session containers ship without a .NET SDK, so an agent working in one cannot
+# run `dotnet build` or `dotnet test` and has to push and wait on CI to find out
+# whether its change even compiles. This installs the SDK and warms the NuGet cache
+# so the unit-test loop works locally.
+#
+# Scope: the base SDK only — NOT the MAUI workload or the Android SDK.
+#   src/Core and tests/MauiApp.Tests both target plain net10.0 and the test project
+#   references only Core, so `dotnet test tests/MauiApp.Tests` needs nothing more.
+#   Building the Android head (src/MauiApp, net10.0-android) additionally needs
+#   `dotnet workload install maui-android` plus an Android SDK; that is a multi-GB
+#   install left to CI deliberately.
+#
+set -euo pipefail
+
+# Local machines have their own toolchain — this hook is for web sessions only.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+# Keep in step with the pin in .github/workflows/ndi-for-android-cicd.yml so local
+# results match CI.
+DOTNET_VERSION="10.0.301"
+DOTNET_INSTALL_DIR="${DOTNET_ROOT:-$HOME/.dotnet}"
+
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_NOLOGO=1
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+log() { echo "[session-start] $*"; }
+
+# ── Install the SDK (idempotent — a cached container keeps it) ────────────────
+
+if [ -x "$DOTNET_INSTALL_DIR/dotnet" ]; then
+  log "SDK already present at $DOTNET_INSTALL_DIR ($("$DOTNET_INSTALL_DIR/dotnet" --version 2>/dev/null || echo unknown))"
+else
+  log "Installing .NET SDK $DOTNET_VERSION into $DOTNET_INSTALL_DIR ..."
+
+  installer="$(mktemp)"
+  trap 'rm -f "$installer"' EXIT
+
+  if ! curl -fsSL --retry 3 --retry-delay 2 --max-time 120 \
+        https://dot.net/v1/dotnet-install.sh -o "$installer"; then
+    cat >&2 <<'BLOCKED'
+[session-start] FAILED: could not download the .NET install script.
+
+This is an egress-policy denial, not a transient error: the environment's network
+policy does not allow the hosts that serve the .NET SDK. Probed from a web session,
+every SDK host returned 403 at the proxy CONNECT while api.nuget.org was reachable.
+
+To make this hook work, allow these hosts in the environment's network policy
+(Claude Code on the web → environment settings → network access):
+
+    dot.net
+    builds.dotnet.microsoft.com
+    aka.ms
+    dotnetcli.azureedge.net
+    download.visualstudio.microsoft.com
+
+Until then a web session cannot build or test locally and must rely on CI.
+See https://code.claude.com/docs/en/claude-code-on-the-web for network policies.
+BLOCKED
+    exit 1
+  fi
+
+  chmod +x "$installer"
+  "$installer" --version "$DOTNET_VERSION" --install-dir "$DOTNET_INSTALL_DIR" --no-path
+  log "SDK installed: $("$DOTNET_INSTALL_DIR/dotnet" --version)"
+fi
+
+export DOTNET_ROOT="$DOTNET_INSTALL_DIR"
+export PATH="$DOTNET_INSTALL_DIR:$PATH"
+
+# ── Persist for the session ───────────────────────────────────────────────────
+
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  {
+    echo "export DOTNET_ROOT=\"$DOTNET_INSTALL_DIR\""
+    echo "export PATH=\"$DOTNET_INSTALL_DIR:\$PATH\""
+    echo 'export DOTNET_CLI_TELEMETRY_OPTOUT=1'
+    echo 'export DOTNET_NOLOGO=1'
+    echo 'export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1'
+  } >> "$CLAUDE_ENV_FILE"
+fi
+
+# ── Warm the package cache and the build ──────────────────────────────────────
+#
+# Restoring and building the test project up front means the agent's first
+# `dotnet test` is fast, and a broken restore surfaces here rather than mid-task.
+# Non-fatal: a warm cache is a convenience, and failing the hook over it would
+# block the session for something the agent can retry itself.
+
+cd "$PROJECT_DIR"
+
+if ! dotnet restore tests/MauiApp.Tests/NdiForAndroid.Tests.csproj --ignore-failed-sources; then
+  log "WARNING: restore failed — the SDK is installed, so retry 'dotnet restore' in-session."
+  exit 0
+fi
+
+if ! dotnet build tests/MauiApp.Tests/NdiForAndroid.Tests.csproj --no-restore; then
+  log "WARNING: warm-up build failed. The SDK is usable; investigate the build error in-session."
+  exit 0
+fi
+
+log "Ready. Unit tests: dotnet test tests/MauiApp.Tests/NdiForAndroid.Tests.csproj"
+log "Note: building src/MauiApp (net10.0-android) needs the maui-android workload — CI only."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `SessionStart` hook so Claude Code on the web sessions have a working .NET SDK.

Motivation: during #302 there was no SDK in the session container, so that change could not be compiled or tested locally at all — CI was the first build. This closes that loop for future sessions.

- `.claude/hooks/session-start.sh` — installs the SDK (pinned to `10.0.301`, matching `ndi-for-android-cicd.yml`), exports `DOTNET_ROOT`/`PATH` via `$CLAUDE_ENV_FILE`, then warms the restore and build of the test project.
- `.claude/settings.json` — new file; registers the hook. The repo had no `settings.json`, only `.claude/agents`, `commands`, and `skills`.

Guarded on `CLAUDE_CODE_REMOTE=true`, so it is a no-op on local machines that already have a toolchain. Idempotent — it skips the install when a cached container already has the SDK.

**Scope is the base SDK only, not the MAUI workload or Android SDK.** `src/Core` and `tests/MauiApp.Tests` both target plain `net10.0`, and the test project references only Core, so `dotnet test tests/MauiApp.Tests` needs nothing more — that is the loop worth having in-session. Building the Android head (`net10.0-android`) additionally needs `dotnet workload install maui-android` plus an Android SDK, which is a multi-GB install left to CI deliberately.

## Validation

- [x] Hook executes and behaves as designed — **but does not currently succeed; see below**
- [ ] Unit tests executed — **not possible**, no SDK could be installed
- [ ] Release build validation executed — not applicable to this change

### The hook cannot work under the current network policy

I ran it (`CLAUDE_CODE_REMOTE=true ./.claude/hooks/session-start.sh`) and it exits 1 at the download step. This is an **egress-policy denial, not a bug in the hook**. Probing from the session:

| Host | Result |
|---|---|
| `dot.net` | 403 |
| `builds.dotnet.microsoft.com` | 403 at proxy CONNECT |
| `aka.ms` | 403 at proxy CONNECT |
| `dotnetcli.azureedge.net` | 403 at proxy CONNECT |
| `download.visualstudio.microsoft.com` | 403 at proxy CONNECT |
| `api.nuget.org` | reachable |

NuGet is allowed, so restore/build/test all work *once an SDK exists* — the only blocked thing is the SDK binary itself. The agent proxy's own documentation is explicit that a 403 is an organization egress-policy denial and must be reported rather than worked around, so the hook does not attempt any fallback.

**To make this hook functional, allow those five hosts in the environment's network policy** (Claude Code on the web → environment settings → network access). The hook prints exactly that list on failure, so whoever hits it next gets an actionable message instead of a bare `curl: (22)`.

I've left this as a draft since it is inert until that policy change — happy to close it instead if you'd rather not carry a hook that doesn't run yet.

### Not validated

- **Unit tests** — could not be run; there is no SDK to run them with. That is the very problem this hook exists to fix, so it is circular until the hosts are allowed.
- **Linter** — the repo has no linter to validate: no `.editorconfig`, no `Directory.Build.props`, no analyzer settings, and no lint step in CI. "Lint" here is just compiler warnings from `dotnet build`.

The hook's own logic *was* exercised: the guard, the version pin, the idempotency check, and the blocked-host error path all ran. The install, env export, and warm-up path have not.

## Governance Checks

- [x] No unauthorized permission additions — no manifest, permission, or dependency changes; nothing ships in the APK
- [x] Toolchain blocker status reviewed — this documents an environment blocker rather than changing the repo toolchain; CI pins are untouched and the hook deliberately matches CI's `10.0.301`
- [x] Design-language and lifecycle safety checks — not applicable, no app code touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfgZfdVVAou7LhzcG3dBWp)_